### PR TITLE
Delete and rate-limit documents processed through the pipeline

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -39,7 +39,10 @@ Task Build {
     Push-Location $RootDir
     [int] $buildNumber = $env:BUILD_COUNTER
     $version = $env:BUILD_NUMBER
-    dotnet build $SolutionFile -c $Configuration /p:Version=$version
+    if ($version -eq $null){
+      $version = "0.0.0"
+    }
+    exec { dotnet build $SolutionFile -c $Configuration /p:Version=$version }
   } finally {
     Pop-Location
   }

--- a/src/Waives.Extensions.DocumentChannels.Filesystem/FileSystemDocumentSource.cs
+++ b/src/Waives.Extensions.DocumentChannels.Filesystem/FileSystemDocumentSource.cs
@@ -17,10 +17,12 @@ namespace Waives.Extensions.DocumentChannels.Filesystem
 
         public static DocumentSource Create(string inbox, bool watch = false)
         {
-            var initialContents = Directory
+            var files = Directory
                 .EnumerateFiles(inbox)
-                .Select(p => new FileSystemDocument(p))
-                .ToObservable();
+                .Select(p => new FileSystemDocument(p));
+
+            Console.WriteLine($"Found {files.Count()} files to process in {inbox}");
+            var initialContents = files.ToObservable();
 
             if (watch)
             {

--- a/src/Waives.Reactive/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Reactive/HttpAdapters/HttpDocument.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Waives.Http.Responses;
 
@@ -11,6 +12,7 @@ namespace Waives.Reactive.HttpAdapters
     internal interface IHttpDocument
     {
         Task<ClassificationResult> Classify(string classifierName);
+        Task Delete(Action afterDeletedAction);
     }
 
     /// <summary>
@@ -31,6 +33,13 @@ namespace Waives.Reactive.HttpAdapters
         public async Task<ClassificationResult> Classify(string classifierName)
         {
             return await _documentClient.Classify(classifierName).ConfigureAwait(false);
+        }
+
+        public async Task Delete(Action afterDeletedAction)
+        {
+            await _documentClient.Delete().ConfigureAwait(false);
+
+            afterDeletedAction();
         }
     }
 }

--- a/src/Waives.Reactive/IRateLimiter.cs
+++ b/src/Waives.Reactive/IRateLimiter.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Waives.Reactive
+{
+    public interface IRateLimiter
+    {
+        void MakeDocumentSlotAvailable();
+        IObservable<TSource> RateLimited<TSource>(IObservable<TSource> source);
+    }
+}

--- a/src/Waives.Reactive/Pipeline.cs
+++ b/src/Waives.Reactive/Pipeline.cs
@@ -148,6 +148,12 @@ namespace Waives.Reactive
         /// this object.</returns>
         public IDisposable Start()
         {
+            _pipeline = _pipeline.SelectMany(async d =>
+            {
+                await d.Delete(() => { }).ConfigureAwait(false);
+                return d;
+            });
+
             var pipelineObserver = new PipelineObserver(_onPipelineCompleted);
             return pipelineObserver.SubscribeTo(_pipeline);
         }

--- a/src/Waives.Reactive/Pipeline.cs
+++ b/src/Waives.Reactive/Pipeline.cs
@@ -53,10 +53,12 @@ namespace Waives.Reactive
         private readonly IHttpDocumentFactory _documentFactory;
         private IObservable<WaivesDocument> _pipeline = Observable.Empty<WaivesDocument>();
         private Action _onPipelineCompleted = () => { };
+        private readonly IRateLimiter _rateLimiter;
 
-        internal Pipeline(IHttpDocumentFactory documentFactory)
+        internal Pipeline(IHttpDocumentFactory documentFactory, IRateLimiter rateLimiter)
         {
             _documentFactory = documentFactory;
+            _rateLimiter = rateLimiter ?? throw new ArgumentNullException(nameof(rateLimiter));
         }
 
         /// <summary>
@@ -67,7 +69,9 @@ namespace Waives.Reactive
         /// <returns>The modified <see cref="Pipeline"/>.</returns>
         public Pipeline WithDocumentsFrom(IObservable<Document> documentSource)
         {
-            _pipeline = documentSource.SelectMany(
+            var rateLimitedDocument = _rateLimiter.RateLimited(documentSource);
+
+            _pipeline = rateLimitedDocument.SelectMany(
                 async d => new WaivesDocument(d, await _documentFactory.CreateDocument(d).ConfigureAwait(false)));
 
             return this;
@@ -150,7 +154,10 @@ namespace Waives.Reactive
         {
             _pipeline = _pipeline.SelectMany(async d =>
             {
-                await d.Delete(() => { }).ConfigureAwait(false);
+                await d.HttpDocument.Delete(() =>
+                {
+                    _rateLimiter.MakeDocumentSlotAvailable();
+                }).ConfigureAwait(false);
                 return d;
             });
 

--- a/src/Waives.Reactive/RateLimiter.cs
+++ b/src/Waives.Reactive/RateLimiter.cs
@@ -8,7 +8,7 @@ using System.Threading;
 namespace Waives.Reactive
 {
     //Inspired by http://granitestatehacker.kataire.com/2016/01/rate-limiting-observables-with-reactive.html
-    public class RateLimiter
+    public class RateLimiter : IRateLimiter
     {
         private readonly IScheduler _scheduler;
         private long _availableDocumentSlots;

--- a/src/Waives.Reactive/RateLimiter.cs
+++ b/src/Waives.Reactive/RateLimiter.cs
@@ -42,6 +42,7 @@ namespace Waives.Reactive
 
             void EmitIfSlotAvailable(ConcurrentQueue<TSource> buffer, IObserver<TSource> observer)
             {
+                Console.WriteLine($"RateLimiter check: There are {_availableDocumentSlots} available document slots");
                 while (Interlocked.Read(ref _availableDocumentSlots) > 0)
                 {
                     if (!buffer.TryDequeue(out var item))

--- a/src/Waives.Reactive/RateLimiter.cs
+++ b/src/Waives.Reactive/RateLimiter.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+
+namespace Waives.Reactive
+{
+    //Inspired by http://granitestatehacker.kataire.com/2016/01/rate-limiting-observables-with-reactive.html
+    public class RateLimiter
+    {
+        private readonly IScheduler _scheduler;
+        private long _availableDocumentSlots;
+        public const byte MaximumConcurrentDocuments = 10;
+
+        public RateLimiter(IScheduler scheduler = null)
+        {
+            _scheduler = scheduler ?? Scheduler.Default;
+            _availableDocumentSlots = MaximumConcurrentDocuments;
+        }
+
+        public void MakeDocumentSlotAvailable()
+        {
+            if (Interlocked.Read(ref _availableDocumentSlots) < MaximumConcurrentDocuments)
+            {
+                Interlocked.Increment(ref _availableDocumentSlots);
+                Console.WriteLine($"RateLimiter: Freed slot. There are now {_availableDocumentSlots} available slots.");
+            }
+        }
+
+        /// <summary>
+        /// Transforms an observable sequence of documents into one where the documents are only
+        /// emitted to the observer when slots are available within the maximum concurrency limit.
+        /// </summary>
+        /// <param name="sourceDocuments">An observable sequence of documents to be rate limited</param>
+        /// <returns>An observable sequence of documents which is rate limited to maximum concurrency</returns>
+        public IObservable<TSource> RateLimited<TSource>(IObservable<TSource> source)
+        {
+            var timeSpan = TimeSpan.FromMilliseconds(500);
+            bool sourceCompleted = false;
+
+            return Observable.Create<TSource>(
+                observer =>
+                {
+                    var buffer = new ConcurrentQueue<TSource>();
+                    Action emitIfSlotAvailable = delegate ()
+                    {
+                        while (Interlocked.Read(ref _availableDocumentSlots) > 0)
+                        {
+                            TSource item;
+                            if (!buffer.TryDequeue(out item))
+                            {
+                                Console.WriteLine("RateLimiter: No more items on queue");
+
+                                if (sourceCompleted)
+                                {
+                                    Console.WriteLine("RateLimiter: Source has completed, so calling observer.OnCompleted");
+                                    observer.OnCompleted();
+                                }
+                                break;
+                            }
+
+                            Console.WriteLine($"RateLimiter: There are {_availableDocumentSlots} slots free. Emitting item {item.ToString()}");
+                            observer.OnNext(item);
+                            Interlocked.Decrement(ref _availableDocumentSlots);
+                        }
+                    };
+
+                    var sourceSub = source
+                        .Subscribe(x =>
+                        {
+                            Console.WriteLine($"RateLimiter: Enqueuing {x.ToString()}");
+                            buffer.Enqueue(x);
+                            emitIfSlotAvailable();
+                        }, () =>
+                        {
+                            Console.WriteLine("RateLimiter: Source has completed. RateLimiter will complete on next check where queue is empty.");
+                            sourceCompleted = true;
+                        });
+
+                    var timer = Observable.Interval(timeSpan, _scheduler)
+                        .Subscribe(x =>
+                        {
+                            Console.WriteLine("DebugRateLimiter: Running check...");
+                            emitIfSlotAvailable();
+                        }, observer.OnError, observer.OnCompleted);
+                    return new CompositeDisposable(sourceSub, timer);
+                });
+        }
+    }
+}

--- a/src/Waives.Reactive/WaivesApi.cs
+++ b/src/Waives.Reactive/WaivesApi.cs
@@ -129,7 +129,9 @@ namespace Waives.Reactive
         /// configure your document processing pipeline.</returns>
         public static Pipeline CreatePipeline()
         {
-            return new Pipeline(new HttpDocumentFactory(ApiClient));
+            return new Pipeline(
+                new HttpDocumentFactory(ApiClient),
+                new RateLimiter());
         }
     }
 }

--- a/src/Waives.Reactive/WaivesDocument.cs
+++ b/src/Waives.Reactive/WaivesDocument.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Waives.Http.Responses;
 using Waives.Reactive.HttpAdapters;
 
@@ -29,6 +30,11 @@ namespace Waives.Reactive
             {
                 ClassificationResults = await _waivesDocument.Classify(classifierName).ConfigureAwait(false)
             };
+        }
+
+        public async Task Delete(Action afterDeletedAction)
+        {
+            await _waivesDocument.Delete(afterDeletedAction).ConfigureAwait(false);
         }
     }
 }

--- a/test/Waives.Reactive.Tests/PipelineFacts.cs
+++ b/test/Waives.Reactive.Tests/PipelineFacts.cs
@@ -122,5 +122,15 @@ namespace Waives.Reactive.Tests
 
             Assert.True(funcWasCalled);
         }
+
+        [Fact]
+        public void The_document_is_deleted_when_processing_completes()
+        {
+            var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);
+            _sut
+                .WithDocumentsFrom(source)
+                .Then(d => d.HttpDocument.Received(1).Delete(Arg.Any<Action>()))
+                .Start();
+        }
     }
 }

--- a/test/Waives.Reactive.Tests/PipelineFacts.cs
+++ b/test/Waives.Reactive.Tests/PipelineFacts.cs
@@ -91,33 +91,36 @@ namespace Waives.Reactive.Tests
         }
 
         [Fact]
-        public void Then_invokes_the_supplied_async_Action()
+        public async Task Then_invokes_the_supplied_async_Action()
         {
             var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);
-            var actionInvoked = false;
+            var completion = new TaskCompletionSource<bool>();
             var pipeline = _sut.WithDocumentsFrom(source)
-                .Then(async d => await Task.Run(() => actionInvoked = true));
+                .Then(async d => await Task.Run(() => completion.SetResult(true)));
 
             pipeline.Start();
+            var actionWasCalled = await completion.Task;
 
-            Assert.True(actionInvoked);
+            Assert.True(actionWasCalled);
         }
 
         [Fact]
-        public void Then_invokes_the_supplied_Func()
+        public async Task Then_invokes_the_supplied_Func()
         {
             var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);
-            var actionInvoked = false;
+            var completion = new TaskCompletionSource<bool>();
+
             var pipeline = _sut.WithDocumentsFrom(source)
-                .Then(async d =>
+                .Then(d =>
                 {
-                    await Task.Run(() => actionInvoked = true);
-                    return d;
+                    completion.SetResult(true);
+                    return Task.FromResult(d);
                 });
 
             pipeline.Start();
+            var funcWasCalled = await completion.Task;
 
-            Assert.True(actionInvoked);
+            Assert.True(funcWasCalled);
         }
     }
 }

--- a/test/Waives.Reactive.Tests/RateLimiterFacts.cs
+++ b/test/Waives.Reactive.Tests/RateLimiterFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using Microsoft.Reactive.Testing;
@@ -17,20 +18,13 @@ namespace Waives.Reactive.Tests
 
             // Schedule one more document than the maximum concurrency, all to be scheduled immediately
             var source = scheduler
-                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments+1));
+                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments + 1));
 
             var rateLimitedDocuments = sut.RateLimited(source);
 
             var testObserver = scheduler.Start(() => rateLimitedDocuments);
 
             Assert.Equal(RateLimiter.MaximumConcurrentDocuments, testObserver.Messages.Count);
-
-            for (var index = 0; index < testObserver.Messages.Count; index++)
-            {
-                var expectedDocumentSourceId = index.ToString();
-                var actualDocumentSourceId = testObserver.Messages[index].Value.Value.SourceId;
-                Assert.Equal(expectedDocumentSourceId, actualDocumentSourceId);
-            }
         }
 
         [Fact]
@@ -63,11 +57,9 @@ namespace Waives.Reactive.Tests
         private static Recorded<Notification<Document>>[] AnArrayOfDocumentNotifications(long numberOfDocuments)
         {
             var notifications = new List<Recorded<Notification<Document>>>();
-            for (long i = 0; i < numberOfDocuments; i++)
-            {
-                notifications.Add(new Recorded<Notification<Document>>(0,
-                    Notification.CreateOnNext<Document>(new TestDocument(Generate.Bytes(), i.ToString()))));
-            }
+            notifications.AddRange(Enumerable.Repeat(
+                new Recorded<Notification<Document>>(0,
+                    Notification.CreateOnNext<Document>(new TestDocument(Generate.Bytes()))), (int) numberOfDocuments));
 
             return notifications.ToArray();
         }

--- a/test/Waives.Reactive.Tests/RateLimiterFacts.cs
+++ b/test/Waives.Reactive.Tests/RateLimiterFacts.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Disposables;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace Waives.Reactive.Tests
+{
+    public class RateLimiterFacts
+    {
+        [Fact]
+        public void Only_output_maximum_allowed_number_of_documents_when_there_are_more_in_input()
+        {
+            var scheduler = new TestScheduler();
+            var sut = new RateLimiter(scheduler);
+
+            // Schedule one more document than the maximum concurrency, all to be scheduled immediately
+            var source = scheduler
+                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments+1));
+
+            var rateLimitedDocuments = sut.RateLimited(source);
+
+            var testObserver = scheduler.Start(() => rateLimitedDocuments);
+
+            Assert.Equal(RateLimiter.MaximumConcurrentDocuments, testObserver.Messages.Count);
+
+            for (var index = 0; index < testObserver.Messages.Count; index++)
+            {
+                var expectedDocumentSourceId = index.ToString();
+                var actualDocumentSourceId = testObserver.Messages[index].Value.Value.SourceId;
+                Assert.Equal(expectedDocumentSourceId, actualDocumentSourceId);
+            }
+        }
+
+        [Fact]
+        public void Outputs_the_documents_as_slots_become_free()
+        {
+            var scheduler = new TestScheduler();
+            var sut = new RateLimiter(scheduler);
+
+            var source = scheduler
+                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments + 1));
+
+            scheduler.ScheduleAbsolute(sut, TimeSpan.FromSeconds(3).Ticks, (_, rateLimiter) =>
+            {
+                rateLimiter.MakeDocumentSlotAvailable();
+                return Disposable.Empty;
+            });
+
+            var testObserver = scheduler.Start(() => sut.RateLimited(source),
+                created: 0, subscribed: 0, disposed: TimeSpan.FromSeconds(5).Ticks);
+
+            Assert.Equal(11, testObserver.Messages.Count);
+        }
+
+        /// <summary>
+        /// Create an array of Document notifications, where each document is scheduled at 1 tick of the
+        /// virtual scheduler
+        /// </summary>
+        /// <param name="numberOfDocuments">The number of document notifications</param>
+        /// <returns></returns>
+        private static Recorded<Notification<Document>>[] AnArrayOfDocumentNotifications(long numberOfDocuments)
+        {
+            var notifications = new List<Recorded<Notification<Document>>>();
+            for (long i = 0; i < numberOfDocuments; i++)
+            {
+                notifications.Add(new Recorded<Notification<Document>>(0,
+                    Notification.CreateOnNext<Document>(new TestDocument(Generate.Bytes(), i.ToString()))));
+            }
+
+            return notifications.ToArray();
+        }
+    }
+}

--- a/test/Waives.Reactive.Tests/TestDocument.cs
+++ b/test/Waives.Reactive.Tests/TestDocument.cs
@@ -5,7 +5,7 @@ namespace Waives.Reactive.Tests
 {
     internal class TestDocument : Document
     {
-        public TestDocument(byte[] contents) : base("Test Document")
+        public TestDocument(byte[] contents, string sourceId = "Test Document") : base(sourceId)
         {
             Stream = new MemoryStream(contents);
         }

--- a/test/Waives.Reactive.Tests/Waives.Reactive.Tests.csproj
+++ b/test/Waives.Reactive.Tests/Waives.Reactive.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
This PR makes two changes:
 - Documents are now deleted from Waives when they reach the end of the pipeline
 - Documents are now rate-limited so that a maximum of 10 are processed at any time, and the next is only processed when there is an available "slot".

Note that the rate limiter assumes that there are 10 "slots" free, i.e. no Waives documents already exist.