### PR TITLE
Delete any orphaned documents when creating a pipeline

### DIFF
--- a/src/Waives.Http/Responses/DocumentCollection.cs
+++ b/src/Waives.Http/Responses/DocumentCollection.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Waives.Http.Responses
+{
+    internal class DocumentCollection
+    {
+        [JsonProperty("documents")]
+        internal IEnumerable<HalResponse> Documents { get; set; }
+    }
+}

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -71,6 +72,15 @@ namespace Waives.Http
             var behaviours = responseContent.Links;
 
             return new Classifier(this, name, behaviours);
+        }
+
+        public async Task<IEnumerable<Document>> GetAllDocuments()
+        {
+            var response = await HttpClient.GetAsync("/documents").ConfigureAwait(false);
+            await EnsureSuccessStatus(response).ConfigureAwait(false);
+
+            var responseContent = await response.Content.ReadAsAsync<DocumentCollection>().ConfigureAwait(false);
+            return responseContent.Documents.Select(d => new Document(this, d.Links));
         }
 
         public async Task Login(string clientId, string clientSecret)

--- a/src/Waives.Reactive/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Reactive/HttpAdapters/WaivesDocumentFactory.cs
@@ -33,9 +33,9 @@ namespace Waives.Reactive.HttpAdapters
             }
         }
 
-        internal static async Task<HttpDocumentFactory> Create(WaivesClient apiClient, bool clearOrphans = true)
+        internal static async Task<HttpDocumentFactory> Create(WaivesClient apiClient, bool deleteOrphanedDocuments = true)
         {
-            if (clearOrphans)
+            if (deleteOrphanedDocuments)
             {
                 await DeleteOrphanedDocuments(apiClient).ConfigureAwait(false);
             }

--- a/src/Waives.Reactive/WaivesApi.cs
+++ b/src/Waives.Reactive/WaivesApi.cs
@@ -125,12 +125,16 @@ namespace Waives.Reactive
         /// }
         /// ]]>
         /// </example>
+        /// <param name="clearOrphans">If set to <c>true</c>, it will (immediately) delete all documents
+        /// in existence in the Waives account; if set to <c>false</c>, no such clean up will be completed.
+        /// Defaults to <c>true</c>.</param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
-        public static Pipeline CreatePipeline()
+        public static Pipeline CreatePipeline(bool clearOrphans = true)
         {
+            var documentFactory = Task.Run(() => HttpDocumentFactory.Create(ApiClient, clearOrphans)).Result;
             return new Pipeline(
-                new HttpDocumentFactory(ApiClient),
+                documentFactory,
                 new RateLimiter());
         }
     }

--- a/src/Waives.Reactive/WaivesApi.cs
+++ b/src/Waives.Reactive/WaivesApi.cs
@@ -125,14 +125,14 @@ namespace Waives.Reactive
         /// }
         /// ]]>
         /// </example>
-        /// <param name="clearOrphans">If set to <c>true</c>, it will (immediately) delete all documents
+        /// <param name="deleteExistingDocuments">If set to <c>true</c>, it will (immediately) delete all documents
         /// in existence in the Waives account; if set to <c>false</c>, no such clean up will be completed.
         /// Defaults to <c>true</c>.</param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
-        public static Pipeline CreatePipeline(bool clearOrphans = true)
+        public static Pipeline CreatePipeline(bool deleteExistingDocuments = true)
         {
-            var documentFactory = Task.Run(() => HttpDocumentFactory.Create(ApiClient, clearOrphans)).Result;
+            var documentFactory = Task.Run(() => HttpDocumentFactory.Create(ApiClient, deleteExistingDocuments)).Result;
             return new Pipeline(
                 documentFactory,
                 new RateLimiter());


### PR DESCRIPTION
This makes two significant changes:

 - `Waives.Http` now exposes a `GetAllDocuments()` operation on `WaivesClient`, which can be used to retrieve all documents currently in existence in the account for further manipulation.
 - `WaivesApi.CreatePipeline()` uses this new API method to delete all documents present in the account as part of the pipeline initialisation. It is possible to skip this step by saying `clearOrphans: false`. 

Clearing the account is a naive operation here; documents created by other processes will be deleted, for example, and there's no option to clear out only some documents. More complicated logic will need to be implemented on a per-application basis. 