### PR TITLE
Add build.sh helper script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+read -r -d '' script <<-"EOF"
+try {
+  & build/_init.ps1; build build,test
+} catch {
+  throw; exit 1
+}
+EOF
+
+# which dumps stderr (?) to console, which makes this a bit noisy.
+# Can it be made quieter?
+pwsh=$(which pwsh-preview || which pwsh || which powershell)
+$pwsh -Command $script


### PR DESCRIPTION
This makes it easier to run the build (with tests) from bash. It's especially helpful when rebasing, as the build and tests can be run after each rebase step, halting the rebase if the build or tests fail:

```
git rebase -ix ./build.sh <new base ref>
```