### PR TITLE
Made max concurrency configurable.

### DIFF
--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -128,6 +128,7 @@ namespace Waives.Pipelines
         /// <param name="deleteExistingDocuments">If set to <c>true</c>, it will (immediately) delete all documents
         /// in existence in the Waives account; if set to <c>false</c>, no such clean up will be completed.
         /// Defaults to <c>true</c>.</param>
+        /// <param name="maxConcurrency">The maximum number of documents to process concurrently.</param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
         public static Pipeline CreatePipeline(bool deleteExistingDocuments = true, int maxConcurrency = RateLimiter.DefaultMaximumConcurrentDocuments)

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -130,12 +130,12 @@ namespace Waives.Pipelines
         /// Defaults to <c>true</c>.</param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
-        public static Pipeline CreatePipeline(bool deleteExistingDocuments = true)
+        public static Pipeline CreatePipeline(bool deleteExistingDocuments = true, int maxConcurrency = RateLimiter.DefaultMaximumConcurrentDocuments)
         {
             var documentFactory = Task.Run(() => HttpDocumentFactory.Create(ApiClient, deleteExistingDocuments)).Result;
             return new Pipeline(
                 documentFactory,
-                new RateLimiter());
+                new RateLimiter(null, maxConcurrency));
         }
     }
 }

--- a/test/Waives.Pipelines.Tests/RateLimiterFacts.cs
+++ b/test/Waives.Pipelines.Tests/RateLimiterFacts.cs
@@ -18,13 +18,13 @@ namespace Waives.Pipelines.Tests
 
             // Schedule one more document than the maximum concurrency, all to be scheduled immediately
             var source = scheduler
-                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments + 1));
+                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.DefaultMaximumConcurrentDocuments + 1));
 
             var rateLimitedDocuments = sut.RateLimited(source);
 
             var testObserver = scheduler.Start(() => rateLimitedDocuments);
 
-            Assert.Equal(RateLimiter.MaximumConcurrentDocuments, testObserver.Messages.Count);
+            Assert.Equal(RateLimiter.DefaultMaximumConcurrentDocuments, testObserver.Messages.Count);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Waives.Pipelines.Tests
             var sut = new RateLimiter(scheduler);
 
             var source = scheduler
-                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.MaximumConcurrentDocuments + 1));
+                .CreateColdObservable(AnArrayOfDocumentNotifications(RateLimiter.DefaultMaximumConcurrentDocuments + 1));
 
             scheduler.ScheduleAbsolute(sut, TimeSpan.FromSeconds(3).Ticks, (_, rateLimiter) =>
             {


### PR DESCRIPTION
As title. This PR allows the user to specify the number of documents to use in waives.

Connects to #16 