### PR TITLE
Add unit tests for WaivesClient and Document classes

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -10,20 +10,20 @@ namespace Waives.Http
     public class Document
     {
         private readonly IHttpRequestSender _requestSender;
-        internal readonly IDictionary<string, HalUri> Behaviours;
+        private readonly IDictionary<string, HalUri> _behaviours;
         public string Id { get; }
 
         internal Document(IHttpRequestSender requestSender, string id, IDictionary<string, HalUri> behaviours)
         {
             _requestSender = requestSender ?? throw new ArgumentNullException(nameof(requestSender));
-            Behaviours = behaviours ?? throw new ArgumentNullException(nameof(behaviours));
+            _behaviours = behaviours ?? throw new ArgumentNullException(nameof(behaviours));
             Id = id ?? throw new ArgumentNullException(nameof(id));
         }
 
         public async Task Read(string resultsFilename, string contentType = null)
         {
             contentType = contentType ?? ContentTypes.WaivesReadResults;
-            var requestUri = Behaviours["document:read"].CreateUri();
+            var requestUri = _behaviours["document:read"].CreateUri();
 
             await DoRead(requestUri).ConfigureAwait(false);
             var httpContent = await GetReadResults(requestUri, contentType).ConfigureAwait(false);
@@ -64,7 +64,7 @@ namespace Waives.Http
 
         public async Task Delete()
         {
-            var selfUrl = Behaviours["self"];
+            var selfUrl = _behaviours["self"];
 
             var request = new HttpRequestMessage(HttpMethod.Delete,
                 selfUrl.CreateUri());
@@ -78,7 +78,7 @@ namespace Waives.Http
 
         public async Task<ClassificationResult> Classify(string classifierName)
         {
-            var classifyUrl = Behaviours["document:classify"];
+            var classifyUrl = _behaviours["document:classify"];
 
             var request = new HttpRequestMessage(HttpMethod.Post,
                 classifyUrl.CreateUri(new

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -13,9 +13,9 @@ namespace Waives.Http
         internal readonly IDictionary<string, HalUri> Behaviours;
         public string Id { get; }
 
-        internal Document(IHttpRequestSender httpClient, string id, IDictionary<string, HalUri> behaviours)
+        internal Document(IHttpRequestSender requestSender, string id, IDictionary<string, HalUri> behaviours)
         {
-            _requestSender = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _requestSender = requestSender ?? throw new ArgumentNullException(nameof(requestSender));
             Behaviours = behaviours ?? throw new ArgumentNullException(nameof(behaviours));
             Id = id ?? throw new ArgumentNullException(nameof(id));
         }

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -9,13 +9,13 @@ namespace Waives.Http
 {
     public class Document
     {
-        private readonly WaivesClient _waivesClient;
-        private readonly IDictionary<string, HalUri> _behaviours;
+        private readonly IHttpRequestSender _requestSender;
+        internal readonly IDictionary<string, HalUri> _behaviours;
         public string Id { get; }
 
-        internal Document(WaivesClient httpClient, string id, IDictionary<string, HalUri> behaviours)
+        internal Document(IHttpRequestSender httpClient, string id, IDictionary<string, HalUri> behaviours)
         {
-            _waivesClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _requestSender = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _behaviours = behaviours ?? throw new ArgumentNullException(nameof(behaviours));
             Id = id ?? throw new ArgumentNullException(nameof(id));
         }
@@ -29,7 +29,7 @@ namespace Waives.Http
             {
                 Content = new StringContent(string.Empty)
             };
-            var readResponse = await _waivesClient.SendRequest(readRequest).ConfigureAwait(false);
+            var readResponse = await _requestSender.Send(readRequest).ConfigureAwait(false);
             if (!readResponse.IsSuccessStatusCode)
             {
                 throw new WaivesApiException("Failed initiating read on document.");
@@ -38,7 +38,7 @@ namespace Waives.Http
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             request.Headers.Add("Accept", contentType);
 
-            var response = await _waivesClient.SendRequest(request).ConfigureAwait(false);
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 throw new WaivesApiException("Failed retrieving document read results.");
@@ -59,7 +59,7 @@ namespace Waives.Http
             var request = new HttpRequestMessage(HttpMethod.Delete,
                 selfUrl.CreateUri());
 
-            var response = await _waivesClient.SendRequest(request).ConfigureAwait(false);
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 throw new WaivesApiException("Failed to delete the document.");
@@ -76,7 +76,7 @@ namespace Waives.Http
                     classifier_name = classifierName
                 }));
 
-            var response = await _waivesClient.SendRequest(request).ConfigureAwait(false);
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 throw new WaivesApiException($"Failed to classify the document with classifier '{classifierName}'");

--- a/src/Waives.Http/IHttpRequestSender.cs
+++ b/src/Waives.Http/IHttpRequestSender.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Waives.Http
+{
+    internal interface IHttpRequestSender
+    {
+        Task<HttpResponseMessage> Send(HttpRequestMessage request);
+    }
+}

--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Waives.Http.Logging;
+
+namespace Waives.Http
+{
+    internal class RequestSender : IHttpRequestSender
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+        internal RequestSender(HttpClient httpClient, ILogger logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        {
+            var stopWatch = new Stopwatch();
+            _logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");
+
+            stopWatch.Start();
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            stopWatch.Stop();
+
+            _logger.Log(LogLevel.Trace, $"Received response from {request.Method} {request.RequestUri} ({response.StatusCode}) ({stopWatch.ElapsedMilliseconds} ms)");
+
+            return response;
+        }
+
+    }
+}

--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -29,6 +29,5 @@ namespace Waives.Http
 
             return response;
         }
-
     }
 }

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -69,7 +69,7 @@ namespace Waives.Http
             var id = responseContent.Id;
             var behaviours = responseContent.Links;
 
-            var document = new Document(_requestSender, behaviours, id);
+            var document = new Document(_requestSender, id, behaviours);
 
             Logger.Log(LogLevel.Trace, $"Created Waives document {id}");
             return document;
@@ -113,7 +113,7 @@ namespace Waives.Http
             await EnsureSuccessStatus(response).ConfigureAwait(false);
 
             var responseContent = await response.Content.ReadAsAsync<DocumentCollection>().ConfigureAwait(false);
-            return responseContent.Documents.Select(d => new Document(_requestSender, d.Links, d.Id));
+            return responseContent.Documents.Select(d => new Document(_requestSender, d.Id, d.Links));
         }
 
         public async Task Login(string clientId, string clientSecret)

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -46,6 +46,22 @@ namespace Waives.Http
                     Content = new StreamContent(documentSource)
                 };
 
+            return await CreateDocument(request).ConfigureAwait(false);
+        }
+
+        public async Task<Document> CreateDocument(string path)
+        {
+            var request =
+                new HttpRequestMessage(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
+                {
+                    Content = new StreamContent(File.OpenRead(path))
+                };
+
+            return await CreateDocument(request).ConfigureAwait(false);
+        }
+
+        private async Task<Document> CreateDocument(HttpRequestMessage request)
+        {
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             await EnsureSuccessStatus(response).ConfigureAwait(false);
 
@@ -57,24 +73,6 @@ namespace Waives.Http
 
             Logger.Log(LogLevel.Trace, $"Created Waives document {id}");
             return document;
-        }
-
-        public async Task<Document> CreateDocument(string path)
-        {
-            var request =
-                new HttpRequestMessage(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
-                {
-                    Content = new StreamContent(File.OpenRead(path))
-                };
-
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
-            await EnsureSuccessStatus(response).ConfigureAwait(false);
-
-            var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
-            var id = responseContent.Id;
-            var behaviours = responseContent.Links;
-
-            return new Document(_requestSender, behaviours, id);
         }
 
         public async Task<Classifier> CreateClassifier(string name, string samplesPath = null)

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -10,6 +10,7 @@ using Waives.Http.Logging;
 using Waives.Http.Responses;
 
 [assembly: InternalsVisibleTo("Waives.Http.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Waives.Pipelines")]
 namespace Waives.Http
 {
@@ -18,7 +19,7 @@ namespace Waives.Http
         internal ILogger Logger { get; set; }
         internal HttpClient HttpClient { get; }
         private const string DefaultUrl = "https://api.waives.io";
-        private readonly RequestSender _requestSender;
+        private readonly IHttpRequestSender _requestSender;
 
         public WaivesClient(ILogger logger = null) : this(new HttpClient { BaseAddress = new Uri(DefaultUrl) }, logger)
         {
@@ -27,10 +28,14 @@ namespace Waives.Http
         internal WaivesClient(HttpClient httpClient) : this(httpClient, new NoopLogger())
         { }
 
-        private WaivesClient(HttpClient httpClient, ILogger logger)
+        private WaivesClient(HttpClient httpClient, ILogger logger) : this(httpClient, logger, new RequestSender(httpClient, logger))
+        { }
+
+        internal WaivesClient(HttpClient httpClient, ILogger logger, IHttpRequestSender requestSender)
         {
             HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             Logger = logger ?? new NoopLogger();
+            _requestSender = requestSender ?? throw new ArgumentNullException(nameof(requestSender));
         }
 
         public async Task<Document> CreateDocument(Stream documentSource)

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -23,7 +23,7 @@ namespace Waives.Http.Tests
 
         public DocumentFacts()
         {
-            var documentId = "id";
+            const string documentId = "id";
             _classifierName = "classifier";
 
             _readUrl = $"/documents/{documentId}/reads";

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using NSubstitute;
+using Waives.Http.Responses;
+using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class DocumentFacts : IDisposable
+    {
+        private readonly IHttpRequestSender _requestSender = Substitute.For<IHttpRequestSender>();
+        private readonly Document _sut;
+        private readonly string _readUrl;
+        private readonly string _classifyUrl;
+        private readonly string _selfUrl;
+        private readonly string _classifierName;
+        private readonly string _readResultsFilename;
+        private readonly string _readResultsResponseContent;
+
+        public DocumentFacts()
+        {
+            var documentId = "id";
+            _classifierName = "classifier";
+
+            _readUrl = $"/documents/{documentId}/reads";
+            _classifyUrl = $"/documents/{documentId}/classify/{_classifierName}";
+            _selfUrl = $"/documents/{documentId}";
+
+            IDictionary<string, HalUri> behaviours = new Dictionary<string, HalUri>
+            {
+                { "document:read", new HalUri(new Uri(_readUrl, UriKind.Relative), false) },
+                { "document:classify", new HalUri(new Uri(_classifyUrl, UriKind.Relative), true) },
+                { "self", new HalUri(new Uri(_selfUrl, UriKind.Relative), false) },
+            };
+
+            _sut = new Document(_requestSender, behaviours, "id");
+
+            _readResultsFilename = Path.GetTempFileName();
+            _readResultsResponseContent = "some text that was read";
+        }
+
+        [Fact]
+        public async Task Delete_sends_request_with_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse());
+
+            await _sut.Delete();
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Delete &&
+                    m.RequestUri.ToString() == _selfUrl));
+        }
+
+        [Fact]
+        public async Task Delete_throws_if_response_is_not_success_code()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AnErrorResponse());
+
+            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Delete());
+        }
+
+        [Fact]
+        public async Task Read_sends_read_request_with_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AGetReadResultsResponse());
+
+            await _sut.Read(_readResultsFilename);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Put &&
+                    m.RequestUri.ToString() == _readUrl));
+        }
+
+        [Fact]
+        public async Task Read_sends_get_read_results_request_with_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AGetReadResultsResponse());
+
+            await _sut.Read(_readResultsFilename);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Get &&
+                    m.RequestUri.ToString() == _readUrl));
+        }
+
+        [Fact]
+        public async Task Read_sends_get_read_results_request_with_specified_content_type()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AGetReadResultsResponse());
+
+            var expectedContentType = "application/text";
+
+            await _sut.Read(_readResultsFilename, expectedContentType);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Get &&
+                    m.Headers.Accept.ToString() == expectedContentType));
+        }
+
+        [Fact]
+        public async Task Read_gets_read_results_in_waives_format_if_content_type_is_not_specified()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AGetReadResultsResponse());
+
+            await _sut.Read(_readResultsFilename);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Get &&
+                    m.Headers.Accept.ToString() == ContentTypes.WaivesReadResults));
+        }
+
+        [Fact]
+        public async Task Read_saves_contents_of_read_results_response_to_specified_file()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AGetReadResultsResponse());
+
+            await _sut.Read(_readResultsFilename);
+
+            var fileContents = await File.ReadAllTextAsync(_readResultsFilename);
+
+            Assert.Equal(_readResultsResponseContent, fileContents);
+        }
+
+        [Fact]
+        public async Task Delete_throws_if_read_response_is_not_success_code()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AnErrorResponse(), AGetReadResultsResponse());
+
+            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+        }
+
+
+        [Fact]
+        public async Task Delete_throws_if_get_read_results_response_is_not_success_code()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ASuccessResponse(), AnErrorResponse());
+
+            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+        }
+
+        [Fact]
+        public async Task Classify_sends_request_with_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AClassifyResponse());
+
+            await _sut.Classify(_classifierName);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    m.RequestUri.ToString() == _classifyUrl));
+        }
+
+        [Fact]
+        public async Task Classify_returns_a_result_with_correct_properties_set()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AClassifyResponse());
+
+            var result = await _sut.Classify(_classifierName);
+
+            Assert.Equal("expectedDocumentType", result.DocumentType);
+            Assert.Equal(2.85512137M, result.RelativeConfidence);
+            Assert.True(result.IsConfident);
+            Assert.Equal(5, result.DocumentTypeScores.Count());
+            Assert.Equal("Assignment of Deed of Trust", result.DocumentTypeScores.First().DocumentType);
+            Assert.Equal(61.4187M, result.DocumentTypeScores.First().Score);
+        }
+
+        [Fact]
+        public async Task Classify_throws_if_response_is_not_success_code()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AnErrorResponse());
+
+            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Classify(_classifierName));
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_readResultsFilename))
+            {
+                File.Delete(_readResultsFilename);
+            }
+        }
+
+        private static HttpResponseMessage ASuccessResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
+        private static HttpResponseMessage AnErrorResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private HttpResponseMessage AGetReadResultsResponse()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_readResultsResponseContent)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("text/plain") }
+                    },
+                };
+        }
+
+        private static HttpResponseMessage AClassifyResponse()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ClassifyResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    },
+                };
+        }
+
+        private const string ClassifyResponse = @"{
+	        ""document_id"": ""expectedDocumentId"",
+            ""classification_results"": {
+                ""document_type"": ""expectedDocumentType"",
+                ""relative_confidence"": 2.85512137,
+                ""is_confident"": true,
+                ""document_type_scores"": [
+                {
+                    ""document_type"": ""Assignment of Deed of Trust"",
+                    ""score"": 61.4187
+
+                },
+                {
+                    ""document_type"": ""Notice of Default"",
+                    ""score"": 32.94312
+                },
+                {
+                    ""document_type"": ""Correspondence"",
+                    ""score"": 28.2860489
+                },
+                {
+                    ""document_type"": ""Deed of Trust"",
+                    ""score"": 28.0011711
+                },
+                {
+                    ""document_type"": ""Notice of Lien"",
+                    ""score"": 27.9561481
+                }
+                ]
+            }
+        }";
+    }
+}

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -68,7 +68,8 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessage>())
                 .Returns(AnErrorResponse());
 
-            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Delete());
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Delete());
+            Assert.Equal("Failed to delete the document.", exception.Message);
         }
 
         [Fact]
@@ -152,13 +153,14 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task Delete_throws_if_read_response_is_not_success_code()
+        public async Task Read_throws_if_read_response_is_not_success_code()
         {
             _requestSender
                 .Send(Arg.Any<HttpRequestMessage>())
                 .Returns(AnErrorResponse(), AGetReadResultsResponse());
 
-            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+            Assert.Equal("Failed initiating read on document.", exception.Message);
         }
 
 
@@ -169,7 +171,8 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessage>())
                 .Returns(ASuccessResponse(), AnErrorResponse());
 
-            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
+            Assert.Equal("Failed retrieving document read results.", exception.Message);
         }
 
         [Fact]
@@ -212,7 +215,9 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessage>())
                 .Returns(AnErrorResponse());
 
-            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Classify(_classifierName));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Classify(_classifierName));
+            Assert.Equal($"Failed to classify the document with classifier '{_classifierName}'",
+                exception.Message);
         }
 
         public void Dispose()

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -37,7 +37,7 @@ namespace Waives.Http.Tests
                 { "self", new HalUri(new Uri(_selfUrl, UriKind.Relative), false) },
             };
 
-            _sut = new Document(_requestSender, behaviours, "id");
+            _sut = new Document(_requestSender, "id", behaviours);
 
             _readResultsFilename = Path.GetTempFileName();
             _readResultsContent = "some text that was read";

--- a/test/Waives.Http.Tests/DummyDocument.txt
+++ b/test/Waives.Http.Tests/DummyDocument.txt
@@ -1,0 +1,1 @@
+﻿Dummy document contents

--- a/test/Waives.Http.Tests/Responses.cs
+++ b/test/Waives.Http.Tests/Responses.cs
@@ -1,0 +1,209 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Xunit.Sdk;
+
+namespace Waives.Http.Tests
+{
+    public static class Responses
+    {
+        public static HttpResponseMessage Success()
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
+        public const string ErrorMessage = "The error message";
+
+        public static HttpResponseMessage ErrorWithMessage()
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent(ErrorResponse)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                }
+            };
+        }
+
+        public static HttpResponseMessage CreateDocument()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(CreateDocumentResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    }
+                };
+        }
+
+        public static HttpResponseMessage GetAllDocuments()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(GetAllDocumentsResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    }
+                };
+        }
+
+        public static HttpResponseMessage GetToken()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(GetTokenResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    },
+                };
+        }
+
+        public static HttpResponseMessage GetReadResults(string content)
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(content)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("text/plain") }
+                    },
+                };
+        }
+
+        public static HttpResponseMessage Classify()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ClassifyResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    },
+                };
+        }
+
+        private const string ClassifyResponse = @"{
+	        ""document_id"": ""expectedDocumentId"",
+            ""classification_results"": {
+                ""document_type"": ""expectedDocumentType"",
+                ""relative_confidence"": 2.85512137,
+                ""is_confident"": true,
+                ""document_type_scores"": [
+                {
+                    ""document_type"": ""Assignment of Deed of Trust"",
+                    ""score"": 61.4187
+
+                },
+                {
+                    ""document_type"": ""Notice of Default"",
+                    ""score"": 32.94312
+                },
+                {
+                    ""document_type"": ""Correspondence"",
+                    ""score"": 28.2860489
+                },
+                {
+                    ""document_type"": ""Deed of Trust"",
+                    ""score"": 28.0011711
+                },
+                {
+                    ""document_type"": ""Notice of Lien"",
+                    ""score"": 27.9561481
+                }
+                ]
+            }
+        }";
+
+        private const string GetTokenResponse = @"{
+	        ""access_token"": ""token"",
+	        ""token_type"": ""Bearer"",
+	        ""expires_in"": 86400}";
+
+        private const string CreateDocumentResponse = @"{
+            ""id"": ""expectedDocumentId"",
+            ""_links"": {
+                ""document:read"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw/reads""
+                },
+                ""document:classify"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw/classify/{classifier_name}"",
+                    ""templated"": true
+                },
+                ""self"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw""
+                }
+            },
+            ""_embedded"": {
+                ""files"": [
+                {
+                    ""id"": ""HEE7UnX680y7yecR-yXsPA"",
+                    ""file_type"": ""Image:TIFF"",
+                    ""size"": 41203,
+                    ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+                }]
+            }
+        }";
+
+        private const string GetAllDocumentsResponse = @"{
+	        ""documents"": [
+              {
+                ""id"": ""expectedDocumentId1"",
+                ""_links"": {
+                    ""document:read"": {
+                        ""href"": ""/documents/expectedDocumentId1/reads""
+                    },
+                    ""document:classify"": {
+                        ""href"": ""/documents/expectedDocumentId1/classify/{classifier_name}"",
+                        ""templated"": true
+                    },
+                    ""self"": {
+                        ""href"": ""/documents/expectedDocumentId1""
+                    }
+                },
+                ""_embedded"": {
+                    ""files"": [
+                    {
+                        ""id"": ""HEE7UnX680y7yecR-yXsPA"",
+                        ""file_type"": ""Image:TIFF"",
+                        ""size"": 41203,
+                        ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+
+                    }
+                    ]
+                 }
+               },
+               {
+                 ""id"": ""expectedDocumentId2"",
+                 ""_links"": {
+                    ""document:read"": {
+                        ""href"": ""/documents/expectedDocumentId2/reads""
+                    },
+                    ""document:classify"": {
+                        ""href"": ""/documents/expectedDocumentId2/classify/{classifier_name}"",
+                        ""templated"": true
+                    },
+                    ""self"": {
+                        ""href"": ""/documents/expectedDocumentId2""
+                    }
+                 },
+                 ""_embedded"": {
+                    ""files"": [
+                    {
+                        ""id"": ""YY-WZbHuukCOXMalCZ3rBA"",
+                        ""file_type"": ""Image:TIFF"",
+                        ""size"": 41203,
+                        ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+                    }
+                    ]
+                }
+            }
+            ]
+        }";
+
+        private const string ErrorResponse = @"{
+	        ""message"": """ + ErrorMessage + "\"}";
+    }
+}

--- a/test/Waives.Http.Tests/Waives.Http.Tests.csproj
+++ b/test/Waives.Http.Tests/Waives.Http.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
@@ -15,6 +16,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Waives.Http\Waives.Http.csproj" />
     <ProjectReference Include="..\MockWaivesApi\MockWaivesApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="DummyDocument.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -1,8 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Waives.Http.Logging;
 using Xunit;

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -1,0 +1,297 @@
+﻿using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Waives.Http.Logging;
+using Xunit;
+using NSubstitute;
+
+namespace Waives.Http.Tests
+{
+    public class WaivesClientFacts
+    {
+        private readonly IHttpRequestSender _requestSender;
+        private readonly WaivesClient _sut;
+        private readonly byte[] _documentContents;
+
+        public WaivesClientFacts()
+        {
+            _requestSender = Substitute.For<IHttpRequestSender>();
+            _sut = new WaivesClient(new HttpClient(),
+                Substitute.For<ILogger>(),
+                _requestSender);
+
+            _documentContents = new byte[] { 0, 1, 2 };
+        }
+
+        [Fact]
+        public async Task CreateDocument_sends_request_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ACreateDocumentResponse());
+
+            using (var stream = new MemoryStream(_documentContents))
+            {
+                await _sut.CreateDocument(stream);
+            }
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    m.RequestUri.ToString() == "/documents"));
+        }
+
+        [Fact]
+        public async Task CreateDocument_sends_the_supplied_stream_as_content()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ACreateDocumentResponse());
+
+            using (var stream = new MemoryStream(_documentContents))
+            {
+                await _sut.CreateDocument(stream);
+
+                await _requestSender
+                    .Received(1)
+                    .Send(Arg.Is<HttpRequestMessage>(m =>
+                        RequestContentEquals(m, _documentContents)));
+            }
+        }
+
+        [Fact]
+        public async Task CreateDocument_sends_the_supplied_file_as_content()
+        {
+            const string filePath = "DummyDocument.txt";
+
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ACreateDocumentResponse());
+
+            await _sut.CreateDocument(filePath);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    RequestContentEquals(m, File.ReadAllBytes(filePath))));
+        }
+
+        [Fact]
+        public async Task CreateDocument_returns_a_document_with_correct_properties_set()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(ACreateDocumentResponse());
+
+            using (var stream = new MemoryStream(_documentContents))
+            {
+                var document = await _sut.CreateDocument(stream);
+
+                Assert.Equal("expectedDocumentId", document.Id);
+                Assert.Equal(new[]
+                    { "document:read", "document:classify", "self" },
+                    document.Behaviours.Keys);
+            }
+        }
+
+        [Fact]
+        public async Task GetAllDocuments_sends_request_correct_url()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AGetAllDocumentsResponse());
+
+            await _sut.GetAllDocuments();
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Get &&
+                    m.RequestUri.ToString() == "/documents"));
+        }
+
+        [Fact]
+        public async Task GetAllDocuments_returns_a_correct_set_of_documents()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AGetAllDocumentsResponse());
+
+            var documents = await _sut.GetAllDocuments();
+
+            var documentsArray = documents.ToArray();
+            Assert.Equal("expectedDocumentId1", documentsArray.First().Id);
+            Assert.Equal("expectedDocumentId2", documentsArray.Last().Id);
+            Assert.Equal(new[] { "document:read", "document:classify", "self" },
+                documentsArray.First().Behaviours.Keys);
+        }
+
+        [Fact]
+        public async Task Login_sends_correct_request()
+        {
+            const string expectedClientId = "clientid";
+            const string expectedClientSecret = "clientsecret";
+
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(AGetTokenResponse());
+
+            await _sut.Login(expectedClientId, expectedClientSecret);
+
+            await _requestSender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    m.Method == HttpMethod.Post &&
+                    IsFormWithClientCredentials(m.Content, expectedClientId, expectedClientSecret)));
+        }
+
+        private bool IsFormWithClientCredentials(HttpContent content, string expectedClientId, string expectedClientSecret)
+        {
+            if (!(content is FormUrlEncodedContent))
+            {
+                return false;
+            }
+
+            var formData = content.ReadAsFormDataAsync().Result;
+
+            Assert.Equal(expectedClientId, formData["client_id"]);
+            Assert.Equal(expectedClientSecret, formData["client_secret"]);
+
+            return true;
+        }
+
+        private bool RequestContentEquals(HttpRequestMessage request, byte[] expectedContents)
+        {
+            var actualRequestContents = request.Content.ReadAsByteArrayAsync().Result;
+
+            return actualRequestContents.SequenceEqual(expectedContents);
+        }
+
+        private static HttpResponseMessage ACreateDocumentResponse()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(CreateDocumentResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    }
+                };
+        }
+
+
+        private static HttpResponseMessage AGetAllDocumentsResponse()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(GetAllDocumentsResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    }
+                };
+        }
+
+        private static HttpResponseMessage AGetTokenResponse()
+        {
+            return
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(GetTokenResponse)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                    },
+                };
+        }
+
+        private const string GetTokenResponse = @"{
+	        ""access_token"": ""token"",
+	        ""token_type"": ""Bearer"",
+	        ""expires_in"": 86400}";
+
+        private const string CreateDocumentResponse = @"{
+            ""id"": ""expectedDocumentId"",
+            ""_links"": {
+                ""document:read"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw/reads""
+                },
+                ""document:classify"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw/classify/{classifier_name}"",
+                    ""templated"": true
+                },
+                ""self"": {
+                    ""href"": ""/documents/LAHV1hoYikqukLpuhiFpAw""
+                }
+            },
+            ""_embedded"": {
+                ""files"": [
+                {
+                    ""id"": ""HEE7UnX680y7yecR-yXsPA"",
+                    ""file_type"": ""Image:TIFF"",
+                    ""size"": 41203,
+                    ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+                }]
+            }
+        }";
+
+        private const string GetAllDocumentsResponse = @"{
+	        ""documents"": [
+              {
+                ""id"": ""expectedDocumentId1"",
+                ""_links"": {
+                    ""document:read"": {
+                        ""href"": ""/documents/expectedDocumentId1/reads""
+                    },
+                    ""document:classify"": {
+                        ""href"": ""/documents/expectedDocumentId1/classify/{classifier_name}"",
+                        ""templated"": true
+                    },
+                    ""self"": {
+                        ""href"": ""/documents/expectedDocumentId1""
+                    }
+                },
+                ""_embedded"": {
+                    ""files"": [
+                    {
+                        ""id"": ""HEE7UnX680y7yecR-yXsPA"",
+                        ""file_type"": ""Image:TIFF"",
+                        ""size"": 41203,
+                        ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+
+                    }
+                    ]
+                 }
+               },
+               {
+                 ""id"": ""expectedDocumentId2"",
+                 ""_links"": {
+                    ""document:read"": {
+                        ""href"": ""/documents/expectedDocumentId2/reads""
+                    },
+                    ""document:classify"": {
+                        ""href"": ""/documents/expectedDocumentId2/classify/{classifier_name}"",
+                        ""templated"": true
+                    },
+                    ""self"": {
+                        ""href"": ""/documents/expectedDocumentId2""
+                    }
+                 },
+                 ""_embedded"": {
+                    ""files"": [
+                    {
+                        ""id"": ""YY-WZbHuukCOXMalCZ3rBA"",
+                        ""file_type"": ""Image:TIFF"",
+                        ""size"": 41203,
+                        ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+                    }
+                    ]
+                }
+            }
+            ]
+        }";
+    }
+}

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -25,7 +25,7 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task CreateDocument_sends_request_correct_url()
+        public async Task CreateDocument_sends_a_request_to_correct_url()
         {
             _requestSender
                 .Send(Arg.Any<HttpRequestMessage>())
@@ -113,7 +113,7 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task GetAllDocuments_sends_request_correct_url()
+        public async Task GetAllDocuments_sends_a_request_to_correct_url()
         {
             _requestSender
                 .Send(Arg.Any<HttpRequestMessage>())
@@ -158,7 +158,7 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task Login_sends_correct_request()
+        public async Task Login_sends_a_request_with_the_specified_credentials()
         {
             const string expectedClientId = "clientid";
             const string expectedClientSecret = "clientsecret";

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -129,7 +129,7 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task GetAllDocuments_returns_a_correct_set_of_documents()
+        public async Task GetAllDocuments_returns_one_document_for_each_returned_by_the_API()
         {
             _requestSender
                 .Send(Arg.Any<HttpRequestMessage>())
@@ -140,8 +140,6 @@ namespace Waives.Http.Tests
             var documentsArray = documents.ToArray();
             Assert.Equal("expectedDocumentId1", documentsArray.First().Id);
             Assert.Equal("expectedDocumentId2", documentsArray.Last().Id);
-            Assert.Equal(new[] { "document:read", "document:classify", "self" },
-                documentsArray.First().Behaviours.Keys);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds unit tests (where there were none) for the WaivesClient and Document classes.

This is enabled by the refactoring of the actual HTTP request sending into a `RequestSender` which is  mocked in the tests so no requests are actually made.

-------------------
Depends on #22 
Starts with commit fe1319b