### PR TITLE
Story/25/add id to document

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -11,7 +11,7 @@ namespace Waives.Http
     {
         private readonly WaivesClient _waivesClient;
         private readonly IDictionary<string, HalUri> _behaviours;
-        internal readonly string Id;
+        public string Id { get; }
 
         internal Document(WaivesClient httpClient, string id, IDictionary<string, HalUri> behaviours)
         {

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -13,6 +13,7 @@ namespace Waives.Pipelines.HttpAdapters
     {
         Task<ClassificationResult> Classify(string classifierName);
         Task Delete(Action afterDeletedAction);
+        string Id { get; }
     }
 
     /// <summary>
@@ -25,7 +26,7 @@ namespace Waives.Pipelines.HttpAdapters
     {
         private readonly Http.Document _documentClient;
 
-        internal string Id => _documentClient.Id;
+        public string Id => _documentClient.Id;
 
         internal HttpDocument(Http.Document documentClient)
         {

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -18,6 +18,8 @@ namespace Waives.Pipelines
             _waivesDocument = waivesDocument;
         }
 
+        public string Id => _waivesDocument.Id;
+
         public Document Source { get; }
 
         internal IHttpDocument HttpDocument => _waivesDocument;


### PR DESCRIPTION
Connects to #25 .

Title says it all, really. Allows calling code to track the Id of documents in Waives.