### PR TITLE
Make HTTP client configurable

### DIFF
--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
 using System.Threading.Tasks;
 using Waives.Http.Logging;
 
@@ -14,6 +16,10 @@ namespace Waives.Http
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            // This is equivalent to the value used by NuGet
+            var productVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Waives.NET", productVersion));
         }
 
         public async Task<HttpResponseMessage> Send(HttpRequestMessage request)

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -16,12 +16,20 @@ namespace Waives.Http
 {
     public class WaivesClient
     {
-        internal ILogger Logger { get; set; }
-        internal HttpClient HttpClient { get; }
         private const string DefaultUrl = "https://api.waives.io";
-        private readonly IHttpRequestSender _requestSender;
 
-        public WaivesClient(ILogger logger = null) : this(new HttpClient { BaseAddress = new Uri(DefaultUrl) }, logger ?? new NoopLogger())
+        internal ILogger Logger { get; set; }
+
+        internal HttpClient HttpClient { get; }
+
+        private readonly IHttpRequestSender _requestSender;
+        public WaivesClient(string apiUrl = DefaultUrl, ILogger logger = null)
+            : this(new HttpClient { BaseAddress = new Uri(apiUrl) }, logger)
+        {
+        }
+
+        public WaivesClient(Uri apiUrl = null, ILogger logger = null)
+            : this(new HttpClient { BaseAddress = apiUrl ?? new Uri(DefaultUrl) }, logger)
         {
         }
 

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -36,6 +36,18 @@ namespace Waives.Http
             HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             Logger = logger ?? new NoopLogger();
             _requestSender = requestSender ?? throw new ArgumentNullException(nameof(requestSender));
+            Timeout = 120;
+        }
+
+        /// <summary>
+        /// Gets or sets a duration on the underlying <see cref="HttpClient"/> to wait
+        /// until the requests time out. The timeout unit is seconds, and defaults to 120.
+        /// </summary>
+        /// <seealso cref="System.Net.Http.HttpClient.Timeout"/>
+        public int Timeout
+        {
+            get => HttpClient.Timeout.Seconds;
+            set => HttpClient.Timeout = TimeSpan.FromSeconds(value);
         }
 
         public async Task<Document> CreateDocument(Stream documentSource)

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Waives.Http;
@@ -11,7 +10,7 @@ namespace Waives.Pipelines
 {
     public static class WaivesApi
     {
-        internal static WaivesClient ApiClient { get; private set; } = new WaivesClient();
+        internal static WaivesClient ApiClient { get; private set; }
 
         /// <summary>
         /// Authenticate against the Waives API.
@@ -47,6 +46,7 @@ namespace Waives.Pipelines
                 throw new ArgumentNullException(nameof(apiUri));
             }
 
+            ApiClient = new WaivesClient(apiUri);
             return await Login(clientId, clientSecret, new Uri(apiUri)).ConfigureAwait(false);
         }
 
@@ -77,7 +77,7 @@ namespace Waives.Pipelines
         /// call the Waives API. This is provided for advanced use cases.</returns>
         public static async Task<WaivesClient> Login(string clientId, string clientSecret, Uri apiUri)
         {
-            ApiClient = new WaivesClient(new HttpClient { BaseAddress = apiUri });
+            ApiClient = new WaivesClient(apiUri);
             await ApiClient.Login(clientId, clientSecret).ConfigureAwait(false);
 
             return ApiClient;


### PR DESCRIPTION
Closes #17 (client timeout); closes #18 (user-agent string); fixes #26 (API URL). 

### Implementation approach

The API URL can now be specified to the `WaivesClient` constructor as either a string or a `Uri` (ensuring compliance with [CA1054](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1054-uri-parameters-should-not-be-strings?view=vs-2017), and ease-of-use for consumers). This only makes sense to be set when the API client is created. 

The client timeout is specified as a property on `WaivesClient`, operating on the underlying `HttpClient` instance. The property accepts an `int` number of seconds, and defaults to 2 minutes, to cater for long-running OCR requests (including implicit OCR steps in classification and extraction requests). It can be set at any time. 

The user-agent string is set in the `RequestSender` class, to ensure that our desired value overrides whatever is passed in. It is currently set to `Waives.NET/<version-string>`, where `<version-string>` is set to `Waives.Http`'s product version. This is the same version number as is exposed via NuGet. There is obviously a lot more information we _could_ include here, and if there are any obvious candidates it would be great to get them in now.

### Design considerations, assumptions

I attempted to collapse the number of constructors into a smaller set. The additional public constructor overload is in place to ensure compliance with [CA1054](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1054-uri-parameters-should-not-be-strings?view=vs-2017) and ease of use (providing a string instead of a `Uri`).

### Further work

There is refactoring required to fully remove the `HttpClient` instance from `WaivesClient` now that the `IHttpRequestSender` interface is in place instead. I started to encroach on this with the constructor work mentioned above, but found it too big a change to complete in this PR. 