### PR TITLE
Fix "The call is ambiguous" between WaivesClient constructors

### DIFF
--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -23,13 +23,9 @@ namespace Waives.Http
         internal HttpClient HttpClient { get; }
 
         private readonly IHttpRequestSender _requestSender;
-        public WaivesClient(string apiUrl = DefaultUrl, ILogger logger = null)
-            : this(new HttpClient { BaseAddress = new Uri(apiUrl) }, logger)
-        {
-        }
 
         public WaivesClient(Uri apiUrl = null, ILogger logger = null)
-            : this(new HttpClient { BaseAddress = apiUrl ?? new Uri(DefaultUrl) }, logger)
+            : this(new HttpClient { BaseAddress = apiUrl ?? new Uri(DefaultUrl) }, logger ?? new NoopLogger())
         {
         }
 

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -46,7 +46,7 @@ namespace Waives.Pipelines
                 throw new ArgumentNullException(nameof(apiUri));
             }
 
-            ApiClient = new WaivesClient(apiUri);
+            ApiClient = new WaivesClient(new Uri(apiUri));
             return await Login(clientId, clientSecret, new Uri(apiUri)).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
This fixes an issue in version `0.7.6-pre`, where `WaivesClient` could not be created without implementing a logger. Not specifying any parameters to the constructor led to an error: "The call is ambiguous between the following methods or properties ...".