### PR TITLE
Retry failed HTTP requests

### DIFF
--- a/src/Waives.Http/ExceptionHandlingRequestSender.cs
+++ b/src/Waives.Http/ExceptionHandlingRequestSender.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Waives.Http
+{
+    internal class ExceptionHandlingRequestSender : IHttpRequestSender
+    {
+        private readonly IHttpRequestSender _wrappedRequestSender;
+
+        public ExceptionHandlingRequestSender(IHttpRequestSender wrappedRequestSender)
+        {
+            _wrappedRequestSender = wrappedRequestSender ?? throw new ArgumentNullException(nameof(wrappedRequestSender));
+        }
+
+        /// <summary>
+        /// Send a request to the wrapped IHttpRequestSender and make sure that any exception is transformed
+        /// into a WaivesApiException.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        {
+            try
+            {
+                return await _wrappedRequestSender.Send(request).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is TaskCanceledException || e is OperationCanceledException)
+            {
+                // Either TaskCanceledException or OperationCanceledException may be thrown by HttpClient if a response
+                // is not received before the HttpClient's TimeOut expires
+                throw new WaivesApiException($"{request.Method} request to {request.RequestUri} timed-out (client-side)");
+            }
+            catch (Exception e)
+            {
+                var message = $"An unexpected error occurred making {request.Method} request to {request.RequestUri}. " +
+                              "Please check the InnerException for more details.";
+
+                throw new WaivesApiException(message, e);
+            }
+        }
+    }
+}

--- a/src/Waives.Http/ExceptionHandlingRequestSender.cs
+++ b/src/Waives.Http/ExceptionHandlingRequestSender.cs
@@ -29,12 +29,12 @@ namespace Waives.Http
             {
                 // Either TaskCanceledException or OperationCanceledException may be thrown by HttpClient if a response
                 // is not received before the HttpClient's TimeOut expires
-                throw new WaivesApiException($"{request.Method} request to {request.RequestUri} timed-out (client-side)");
+                throw new WaivesApiException($"{request.Method} request to {request.RequestUri} timed-out.");
             }
             catch (Exception e)
             {
                 var message = $"An unexpected error occurred making {request.Method} request to {request.RequestUri}. " +
-                              "Please check the InnerException for more details.";
+                              $"The error was: {e.Message}.";
 
                 throw new WaivesApiException(message, e);
             }

--- a/src/Waives.Http/ExponentialBackoffSleepProvider.cs
+++ b/src/Waives.Http/ExponentialBackoffSleepProvider.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Waives.Http
+{
+    public class ExponentialBackoffSleepProvider
+    {
+        private readonly Random _jitterer = new Random();
+
+        // With 8 retries, we get retries at the following base times:
+        // 0s, 1s, 3s, 7s, 15s, 31s, 63s and 127s
+        // But we will also have additional jitter time of between
+        // 0 and 36s (1+2+..+8s)
+        public TimeSpan GetSleepDuration(int retry)
+        {
+            var baseDelay = TimeSpan.FromSeconds(Math.Pow(2, retry - 1));
+
+            // Add some jitter so we spread out retried requests if we had
+            // a system glitch that affected multiple requests
+            var jitterDelay = TimeSpan.FromMilliseconds(
+                _jitterer.Next(0, 1000 * retry));
+
+            return baseDelay + jitterDelay;
+        }
+    }
+}

--- a/src/Waives.Http/ExponentialBackoffSleepProvider.cs
+++ b/src/Waives.Http/ExponentialBackoffSleepProvider.cs
@@ -8,8 +8,6 @@ namespace Waives.Http
 
         // With 8 retries, we get retries at the following base times:
         // 0s, 1s, 3s, 7s, 15s, 31s, 63s and 127s
-        // But we will also have additional jitter time of between
-        // 0 and 36s (1+2+..+8s)
         public TimeSpan GetSleepDuration(int retry)
         {
             var baseDelay = TimeSpan.FromSeconds(Math.Pow(2, retry - 1));
@@ -17,7 +15,7 @@ namespace Waives.Http
             // Add some jitter so we spread out retried requests if we had
             // a system glitch that affected multiple requests
             var jitterDelay = TimeSpan.FromMilliseconds(
-                _jitterer.Next(0, 1000 * retry));
+                _jitterer.Next(0, 1000));
 
             return baseDelay + jitterDelay;
         }

--- a/src/Waives.Http/ExponentialBackoffSleepProvider.cs
+++ b/src/Waives.Http/ExponentialBackoffSleepProvider.cs
@@ -2,7 +2,7 @@
 
 namespace Waives.Http
 {
-    public class ExponentialBackoffSleepProvider
+    internal class ExponentialBackoffSleepProvider
     {
         private readonly Random _jitterer = new Random();
 

--- a/src/Waives.Http/HttpRequestMessageExtensions.cs
+++ b/src/Waives.Http/HttpRequestMessageExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Waives.Http
+{
+    public static class HttpRequestMessageExtensions
+    {
+        public static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Content = await request.Content.CloneAsync().ConfigureAwait(false),
+                Version = request.Version
+            };
+
+            foreach (var prop in request.Properties)
+            {
+                clone.Properties.Add(prop);
+            }
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
+        }
+
+        private static async Task<HttpContent> CloneAsync(this HttpContent content)
+        {
+            if (content == null) return null;
+
+            var ms = new MemoryStream();
+            await content.CopyToAsync(ms).ConfigureAwait(false);
+            ms.Position = 0;
+
+            var clone = new StreamContent(ms);
+            foreach (var header in content.Headers)
+            {
+                clone.Headers.Add(header.Key, header.Value);
+            }
+            return clone;
+        }
+    }
+}

--- a/src/Waives.Http/HttpRequestMessageExtensions.cs
+++ b/src/Waives.Http/HttpRequestMessageExtensions.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 
 namespace Waives.Http
 {
-    public static class HttpRequestMessageExtensions
+    internal static class HttpRequestMessageExtensions
     {
-        public static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage request)
+        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage request)
         {
             var clone = new HttpRequestMessage(request.Method, request.RequestUri)
             {

--- a/src/Waives.Http/LoggingRequestSender.cs
+++ b/src/Waives.Http/LoggingRequestSender.cs
@@ -35,9 +35,14 @@ namespace Waives.Http
             }
             catch (WaivesApiException e)
             {
-                Logger.Log(LogLevel.Error,
-                    e.InnerException != null ? $"{e.Message} Inner exception: {e.InnerException.Message}" : e.Message);
-
+                if (e.InnerException != null)
+                {
+                    Logger.Log(LogLevel.Error, $"{e.Message} Inner exception: {e.InnerException.Message}");
+                }
+                else
+                {
+                    Logger.Log(LogLevel.Error, e.Message);
+                }
                 throw;
             }
         }

--- a/src/Waives.Http/LoggingRequestSender.cs
+++ b/src/Waives.Http/LoggingRequestSender.cs
@@ -9,18 +9,18 @@ namespace Waives.Http
     internal class LoggingRequestSender : IHttpRequestSender
     {
         private readonly IHttpRequestSender _wrappedRequestSender;
-        private readonly ILogger _logger;
+        internal ILogger Logger;
 
         public LoggingRequestSender(IHttpRequestSender wrappedRequestSender, ILogger logger)
         {
             _wrappedRequestSender = wrappedRequestSender ?? throw new ArgumentNullException(nameof(wrappedRequestSender));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
         {
             var stopWatch = new Stopwatch();
-            _logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");
+            Logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");
 
             try
             {
@@ -28,14 +28,14 @@ namespace Waives.Http
                 var response = await _wrappedRequestSender.Send(request).ConfigureAwait(false);
                 stopWatch.Stop();
 
-                _logger.Log(LogLevel.Trace,
+                Logger.Log(LogLevel.Trace,
                     $"Received response from {request.Method} {request.RequestUri} ({response.StatusCode}) ({stopWatch.ElapsedMilliseconds} ms)");
 
                 return response;
             }
             catch (WaivesApiException e)
             {
-                _logger.Log(LogLevel.Error,
+                Logger.Log(LogLevel.Error,
                     e.InnerException != null ? $"{e.Message} Inner exception: {e.InnerException.Message}" : e.Message);
 
                 throw;

--- a/src/Waives.Http/LoggingRequestSender.cs
+++ b/src/Waives.Http/LoggingRequestSender.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Waives.Http.Logging;
+
+namespace Waives.Http
+{
+    internal class LoggingRequestSender : IHttpRequestSender
+    {
+        private readonly IHttpRequestSender _wrappedRequestSender;
+        private readonly ILogger _logger;
+
+        public LoggingRequestSender(IHttpRequestSender wrappedRequestSender, ILogger logger)
+        {
+            _wrappedRequestSender = wrappedRequestSender ?? throw new ArgumentNullException(nameof(wrappedRequestSender));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        {
+            var stopWatch = new Stopwatch();
+            _logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");
+
+            try
+            {
+                stopWatch.Start();
+                var response = await _wrappedRequestSender.Send(request).ConfigureAwait(false);
+                stopWatch.Stop();
+
+                _logger.Log(LogLevel.Trace,
+                    $"Received response from {request.Method} {request.RequestUri} ({response.StatusCode}) ({stopWatch.ElapsedMilliseconds} ms)");
+
+                return response;
+            }
+            catch (WaivesApiException e)
+            {
+                _logger.Log(LogLevel.Error,
+                    e.InnerException != null ? $"{e.Message} Inner exception: {e.InnerException.Message}" : e.Message);
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Waives.Http/ReliableRequestSender.cs
+++ b/src/Waives.Http/ReliableRequestSender.cs
@@ -16,9 +16,9 @@ namespace Waives.Http
         {
             var sleepDurationProvider = new ExponentialBackoffSleepProvider();
 
-            _policy = HttpPolicyExtensions
-                .HandleTransientHttpError()
-                .Or<WaivesApiException>()
+            _policy = Policy
+                .Handle<WaivesApiException>()
+                .OrTransientHttpStatusCode()
                 .WaitAndRetryAsync(8,
                     sleepDurationProvider.GetSleepDuration,
                     retryAction);

--- a/src/Waives.Http/ReliableRequestSender.cs
+++ b/src/Waives.Http/ReliableRequestSender.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Extensions.Http;
+using Polly.Retry;
+
+namespace Waives.Http
+{
+    internal class ReliableRequestSender : IHttpRequestSender
+    {
+        private readonly IHttpRequestSender _wrappedRequestSender;
+        private readonly RetryPolicy<HttpResponseMessage> _policy;
+
+        public ReliableRequestSender(Action<DelegateResult<HttpResponseMessage>, TimeSpan, int, Context> retryAction, IHttpRequestSender wrappedRequestSender)
+        {
+            var sleepDurationProvider = new ExponentialBackoffSleepProvider();
+
+            _policy = HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .Or<WaivesApiException>()
+                .WaitAndRetryAsync(8,
+                    sleepDurationProvider.GetSleepDuration,
+                    retryAction);
+
+            _wrappedRequestSender = wrappedRequestSender ?? throw new ArgumentNullException(nameof(wrappedRequestSender));
+        }
+
+        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        {
+            return await _policy
+                .ExecuteAsync(() =>
+                    SendClonedRequest(request))
+                .ConfigureAwait(false);
+        }
+
+        private async Task<HttpResponseMessage> SendClonedRequest(HttpRequestMessage request)
+        {
+            // HttpClient does not allow an HttpRequestMessage to be sent more than once,
+            // which would cause an issue if we retry, so clone the request first and send the
+            // clone to the wrapped sender.
+            var clonedRequest = await request.CloneAsync().ConfigureAwait(false);
+            return await _wrappedRequestSender.Send(clonedRequest).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -4,18 +4,16 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
-using Waives.Http.Logging;
 
 namespace Waives.Http
 {
     internal class RequestSender : IHttpRequestSender
     {
         private readonly HttpClient _httpClient;
-        private readonly ILogger _logger;
-        internal RequestSender(HttpClient httpClient, ILogger logger)
+
+        internal RequestSender(HttpClient httpClient)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             // This is equivalent to the value used by NuGet
             var productVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
@@ -24,16 +22,7 @@ namespace Waives.Http
 
         public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
         {
-            var stopWatch = new Stopwatch();
-            _logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");
-
-            stopWatch.Start();
-            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
-            stopWatch.Stop();
-
-            _logger.Log(LogLevel.Trace, $"Received response from {request.Method} {request.RequestUri} ({response.StatusCode}) ({stopWatch.ElapsedMilliseconds} ms)");
-
-            return response;
+            return await _httpClient.SendAsync(request).ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Http/Waives.Http.csproj
+++ b/src/Waives.Http/Waives.Http.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Polly" Version="6.1.0" />
+    <PackageReference Include="Polly.Extensions.Http" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -37,7 +37,8 @@ namespace Waives.Http
         {
             HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             Logger = logger ?? new NoopLogger();
-            _requestSender = requestSender ?? new ReliableRequestSender(RetryAction,
+            _requestSender = requestSender ??
+                             new ReliableRequestSender(RetryAction,
                                  new LoggingRequestSender(
                                      new ExceptionHandlingRequestSender(
                                          new RequestSender(httpClient)),

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -26,14 +26,11 @@ namespace Waives.Http
         private readonly IHttpRequestSender _requestSender;
 
         public WaivesClient(Uri apiUrl = null, ILogger logger = null)
-            : this(new HttpClient { BaseAddress = apiUrl ?? new Uri(DefaultUrl) }, logger ?? new NoopLogger())
+            : this(new HttpClient { BaseAddress = apiUrl ?? new Uri(DefaultUrl) }, logger ?? new NoopLogger(), null)
         {
         }
 
-        internal WaivesClient(HttpClient httpClient) : this(httpClient, new NoopLogger())
-        { }
-
-        private WaivesClient(HttpClient httpClient, ILogger logger) : this(httpClient, logger, new RequestSender(httpClient, logger))
+        internal WaivesClient(HttpClient httpClient) : this(httpClient, new NoopLogger(), null)
         { }
 
         internal WaivesClient(HttpClient httpClient, ILogger logger, IHttpRequestSender requestSender)
@@ -43,7 +40,7 @@ namespace Waives.Http
             _requestSender = requestSender ?? new ReliableRequestSender(RetryAction,
                                  new LoggingRequestSender(
                                      new ExceptionHandlingRequestSender(
-                                         new RequestSender(httpClient, logger)),
+                                         new RequestSender(httpClient)),
                                      logger));
             Timeout = 120;
         }

--- a/test/Waives.Http.Tests/ExceptionHandlingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/ExceptionHandlingRequestSenderFacts.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class ExceptionHandlingRequestSenderFacts
+    {
+        private readonly IHttpRequestSender _sender;
+        private readonly HttpRequestMessage _request;
+        private readonly ExceptionHandlingRequestSender _sut;
+
+        public ExceptionHandlingRequestSenderFacts()
+        {
+            _sender = Substitute.For<IHttpRequestSender>();
+            _sut = new ExceptionHandlingRequestSender(_sender);
+
+            _request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+        }
+
+        [Fact]
+        public async Task Returns_response_from_wrapped_sender()
+        {
+            var expectedResponse = Responses.Success();
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(expectedResponse);
+
+            var response = await _sut.Send(_request);
+
+            Assert.Same(expectedResponse, response);
+        }
+
+        [Theory]
+        [MemberData(nameof(TimeoutExceptions))]
+        public async Task Throws_WaivesApiException_if_wrapped_sender_times_out(Exception senderException)
+        {
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(senderException);
+
+            await Assert.ThrowsAsync<WaivesApiException>(() =>
+                _sut.Send(_request));
+        }
+
+        [Theory]
+        [MemberData(nameof(TimeoutExceptions))]
+        public async Task Includes_request_details_in_exception_if_wrapped_sender_times_out(Exception senderException)
+        {
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(senderException);
+
+            var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
+                _sut.Send(_request));
+
+            Assert.Contains(_request.Method.ToString(), actualException.Message);
+            Assert.Contains(_request.RequestUri.ToString(), actualException.Message);
+        }
+
+        [Fact]
+        public async Task Throws_WaivesApiException_if_wrapped_sender_throws_another_exception()
+        {
+            var expectedException = new Exception("an error message");
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(expectedException);
+
+            await Assert.ThrowsAsync<WaivesApiException>(() =>
+                _sut.Send(_request));
+        }
+
+        [Fact]
+        public async Task Includes_original_exception_as_inner_exception_if_wrapped_sender_throws_another_exception()
+        {
+            var expectedException = new Exception("an error message");
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(expectedException);
+
+            var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
+                _sut.Send(_request));
+
+            Assert.Same(expectedException, actualException.InnerException);
+        }
+
+        [Fact]
+        public async Task Includes_request_details_in_exception_if_wrapped_sender_throws_another_exception()
+        {
+            var expectedException = new Exception("an error message");
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(expectedException);
+
+            var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
+                _sut.Send(_request));
+
+            Assert.Contains(_request.Method.ToString(), actualException.Message);
+            Assert.Contains(_request.RequestUri.ToString(), actualException.Message);
+        }
+
+        // If HttpClient times-out (client-side) then one of these exceptions is thrown
+        // ReSharper disable once MemberCanBePrivate.Global
+        public static IEnumerable<object[]> TimeoutExceptions()
+        {
+            yield return new object[] { new TaskCanceledException() };
+            yield return new object[] { new OperationCanceledException() };
+        }
+    }
+}

--- a/test/Waives.Http.Tests/ExponentialBackoffSleepProviderFacts.cs
+++ b/test/Waives.Http.Tests/ExponentialBackoffSleepProviderFacts.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class ExponentialBackoffSleepProviderFacts
+    {
+        [Theory]
+        [InlineData(1, 1000, 2000)] //1000 + 1*1000
+        [InlineData(2, 2000, 4000)] //2000 + 2*1000
+        [InlineData(3, 4000, 7000)] //4000 + 3*1000
+        [InlineData(4, 8000, 12000)] //8000 + 4*1000
+        [InlineData(5, 16000, 21000)] //16000 + 5*1000
+        [InlineData(6, 32000, 38000)] //32000 + 6*1000
+        [InlineData(7, 64000, 71000)] //64000 + 7*1000
+        [InlineData(8, 128000, 136000)] //128000 + 8*1000
+        public void Test(int retry, int expectedMinDuration, int expectedMaxDuration)
+        {
+            var sut = new ExponentialBackoffSleepProvider();
+            var timespan = sut.GetSleepDuration(retry);
+
+            Assert.InRange(timespan.TotalMilliseconds, expectedMinDuration, expectedMaxDuration);
+        }
+    }
+}

--- a/test/Waives.Http.Tests/ExponentialBackoffSleepProviderFacts.cs
+++ b/test/Waives.Http.Tests/ExponentialBackoffSleepProviderFacts.cs
@@ -5,14 +5,14 @@ namespace Waives.Http.Tests
     public class ExponentialBackoffSleepProviderFacts
     {
         [Theory]
-        [InlineData(1, 1000, 2000)] //1000 + 1*1000
-        [InlineData(2, 2000, 4000)] //2000 + 2*1000
-        [InlineData(3, 4000, 7000)] //4000 + 3*1000
-        [InlineData(4, 8000, 12000)] //8000 + 4*1000
-        [InlineData(5, 16000, 21000)] //16000 + 5*1000
-        [InlineData(6, 32000, 38000)] //32000 + 6*1000
-        [InlineData(7, 64000, 71000)] //64000 + 7*1000
-        [InlineData(8, 128000, 136000)] //128000 + 8*1000
+        [InlineData(1, 1000, 2000)]
+        [InlineData(2, 2000, 3000)]
+        [InlineData(3, 4000, 5000)]
+        [InlineData(4, 8000, 9000)]
+        [InlineData(5, 16000, 17000)]
+        [InlineData(6, 32000, 33000)]
+        [InlineData(7, 64000, 65000)]
+        [InlineData(8, 128000, 129000)]
         public void Test(int retry, int expectedMinDuration, int expectedMaxDuration)
         {
             var sut = new ExponentialBackoffSleepProvider();

--- a/test/Waives.Http.Tests/LoggingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/LoggingRequestSenderFacts.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Waives.Http.Logging;
+using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class LoggingRequestSenderFacts
+    {
+        private readonly IHttpRequestSender _sender;
+        private readonly ILogger _logger;
+        private readonly LoggingRequestSender _sut;
+        private readonly HttpRequestMessage _request;
+
+        public LoggingRequestSenderFacts()
+        {
+            _sender = Substitute.For<IHttpRequestSender>();
+            _logger = Substitute.For<ILogger>();
+            _sut = new LoggingRequestSender(_sender, _logger);
+
+            _request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+        }
+
+        [Fact]
+        public async Task Returns_response_from_wrapped_sender()
+        {
+            var expectedResponse = Responses.Success();
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(expectedResponse);
+
+            var response = await _sut.Send(_request);
+
+            Assert.Same(expectedResponse, response);
+        }
+
+        [Fact]
+        public async Task Rethrows_original_exception_when_wrapped_sender_throws_exception()
+        {
+            var expectedException = new WaivesApiException();
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(expectedException);
+
+            try
+            {
+                await _sut.Send(_request);
+            }
+            catch (WaivesApiException e)
+            {
+                Assert.Same(expectedException, e);
+                return;
+            }
+
+            Assert.False(true);
+        }
+
+        [Fact]
+        public async Task Logs_two_trace_messages_when_request_is_successful()
+        {
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(Responses.Success());
+
+            await _sut.Send(_request);
+
+            _logger.Received(2)
+                .Log(LogLevel.Trace, Arg.Any<string>());
+        }
+
+        [Fact]
+        public async Task Logs_a_trace_and_an_error_message_when_wrapped_sender_throws_exception()
+        {
+            var exception = new WaivesApiException("an error message");
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(exception);
+
+            try
+            {
+                await _sut.Send(_request);
+            }
+            catch (WaivesApiException)
+            {
+                _logger.Received(1)
+                    .Log(LogLevel.Trace, Arg.Any<string>());
+
+                _logger.Received(1)
+                    .Log(LogLevel.Error, Arg.Any<string>());
+
+                return;
+            }
+
+            Assert.False(true);
+        }
+
+        [Fact]
+        public async Task Logs_an_error_message_that_includes_the_exception_message()
+        {
+            var exception = new WaivesApiException("an error message");
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(exception);
+
+            try
+            {
+                await _sut.Send(_request);
+            }
+            catch (WaivesApiException)
+            {
+                _logger.Received(1)
+                    .Log(LogLevel.Error, Arg.Is<string>(m => m.Contains(exception.Message)));
+
+                return;
+            }
+
+            Assert.False(true);
+        }
+
+        [Fact]
+        public async Task Logs_an_error_message_that_includes_the_inner_exception_message_if_set()
+        {
+            var innerException = new Exception("inner message");
+            var exception = new WaivesApiException("an error message", innerException);
+
+            _sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Throws(exception);
+
+            try
+            {
+                await _sut.Send(_request);
+            }
+            catch (WaivesApiException)
+            {
+                _logger.Received(1)
+                    .Log(LogLevel.Error, Arg.Is<string>(m => m.Contains(innerException.Message)));
+
+                return;
+            }
+
+            Assert.False(true);
+        }
+    }
+}

--- a/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -53,10 +54,7 @@ namespace Waives.Http.Tests
         }
 
         [Theory]
-        [InlineData(HttpStatusCode.Continue)]         //100
-        [InlineData(HttpStatusCode.OK)]               //200
-        [InlineData(HttpStatusCode.MultipleChoices)]  //300
-        [InlineData(HttpStatusCode.BadRequest)]       //400
+        [MemberData(nameof(NoRetryHttpStatusCodes))]
         public async Task Send_does_not_retry_on_satisfactory_responses(HttpStatusCode statusCode)
         {
             var sender = Substitute.For<IHttpRequestSender>();
@@ -145,6 +143,49 @@ namespace Waives.Http.Tests
             Assert.True(expectedContent.SequenceEqual(actualContent));
 
             return true;
+        }
+
+        public static IEnumerable<object[]> NoRetryHttpStatusCodes()
+        {
+            yield return new object[] { HttpStatusCode.Continue };
+            yield return new object[] { HttpStatusCode.SwitchingProtocols };
+            yield return new object[] { HttpStatusCode.OK };
+            yield return new object[] { HttpStatusCode.Created };
+            yield return new object[] { HttpStatusCode.Accepted };
+            yield return new object[] { HttpStatusCode.NonAuthoritativeInformation };
+            yield return new object[] { HttpStatusCode.NoContent };
+            yield return new object[] { HttpStatusCode.ResetContent };
+            yield return new object[] { HttpStatusCode.PartialContent };
+            yield return new object[] { HttpStatusCode.MultipleChoices };
+            yield return new object[] { HttpStatusCode.Ambiguous };
+            yield return new object[] { HttpStatusCode.MovedPermanently };
+            yield return new object[] { HttpStatusCode.Moved };
+            yield return new object[] { HttpStatusCode.Found };
+            yield return new object[] { HttpStatusCode.Redirect };
+            yield return new object[] { HttpStatusCode.SeeOther };
+            yield return new object[] { HttpStatusCode.NotModified };
+            yield return new object[] { HttpStatusCode.UseProxy };
+            yield return new object[] { HttpStatusCode.Unused };
+            yield return new object[] { HttpStatusCode.TemporaryRedirect };
+            yield return new object[] { HttpStatusCode.RedirectKeepVerb };
+            yield return new object[] { HttpStatusCode.BadRequest };
+            yield return new object[] { HttpStatusCode.Unauthorized };
+            yield return new object[] { HttpStatusCode.PaymentRequired };
+            yield return new object[] { HttpStatusCode.Forbidden };
+            yield return new object[] { HttpStatusCode.NotFound };
+            yield return new object[] { HttpStatusCode.MethodNotAllowed };
+            yield return new object[] { HttpStatusCode.NotAcceptable };
+            yield return new object[] { HttpStatusCode.ProxyAuthenticationRequired };
+            yield return new object[] { HttpStatusCode.Conflict };
+            yield return new object[] { HttpStatusCode.Gone };
+            yield return new object[] { HttpStatusCode.LengthRequired };
+            yield return new object[] { HttpStatusCode.PreconditionFailed };
+            yield return new object[] { HttpStatusCode.RequestEntityTooLarge };
+            yield return new object[] { HttpStatusCode.RequestUriTooLong };
+            yield return new object[] { HttpStatusCode.UnsupportedMediaType };
+            yield return new object[] { HttpStatusCode.RequestedRangeNotSatisfiable };
+            yield return new object[] { HttpStatusCode.ExpectationFailed };
+            yield return new object[] { HttpStatusCode.UpgradeRequired };
         }
 
         private class RetryLogger

--- a/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using NSubstitute;
+using Polly;
+using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class ReliableRequestSenderFacts
+    {
+        private readonly RetryLogger _retryLogger;
+        private readonly HttpRequestMessage _request;
+
+        public ReliableRequestSenderFacts()
+        {
+            _retryLogger = new RetryLogger();
+            _request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.RequestTimeout)]      //408
+        [InlineData(HttpStatusCode.InternalServerError)] //500
+        [InlineData(HttpStatusCode.NotImplemented)]      //501
+        [InlineData(HttpStatusCode.BadGateway)]          //502
+        [InlineData(HttpStatusCode.ServiceUnavailable)]  //503
+        [InlineData(HttpStatusCode.GatewayTimeout)]      //504
+        [InlineData(HttpStatusCode.HttpVersionNotSupported)] //505
+        [InlineData(HttpStatusCode.VariantAlsoNegotiates)]   //506
+        [InlineData(HttpStatusCode.InsufficientStorage)] //507
+        [InlineData(HttpStatusCode.LoopDetected)]        //508
+        [InlineData(HttpStatusCode.NotExtended)]         //509
+        [InlineData(HttpStatusCode.NetworkAuthenticationRequired)] //510
+        public async Task Send_retries_on_error_response(HttpStatusCode statusCode)
+        {
+            var sender = Substitute.For<IHttpRequestSender>();
+            sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(
+                    new HttpResponseMessage(statusCode),
+                    Responses.Success());
+
+            var sut = new ReliableRequestSender(
+                _retryLogger.RetryAction,
+                sender);
+
+            await sut.Send(_request);
+
+            Assert.True(_retryLogger.RetryActionCalled);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Continue)]         //100
+        [InlineData(HttpStatusCode.OK)]               //200
+        [InlineData(HttpStatusCode.MultipleChoices)]  //300
+        [InlineData(HttpStatusCode.BadRequest)]       //400
+        public async Task Send_does_not_retry_on_satisfactory_responses(HttpStatusCode statusCode)
+        {
+            var sender = Substitute.For<IHttpRequestSender>();
+            sender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(
+                    new HttpResponseMessage(statusCode),
+                    Responses.Success());
+
+            var sut = new ReliableRequestSender(
+                _retryLogger.RetryAction,
+                sender);
+
+            await sut.Send(_request);
+
+            Assert.False(_retryLogger.RetryActionCalled);
+        }
+
+        [Fact]
+        public async Task Send_retries_on_http_exception()
+        {
+            var sender = Substitute.For<IHttpRequestSender>();
+
+            sender.Send(Arg.Any<HttpRequestMessage>())
+                .Returns(x => throw new HttpRequestException(), x => Responses.Success());
+
+            var sut = new ReliableRequestSender(
+                _retryLogger.RetryAction,
+                sender);
+
+            await sut.Send(_request);
+
+            Assert.True(_retryLogger.RetryActionCalled);
+        }
+
+        [Fact]
+        public async Task Send_retries_on_waives_api_exception()
+        {
+            var sender = Substitute.For<IHttpRequestSender>();
+
+            sender.Send(Arg.Any<HttpRequestMessage>())
+                .Returns(x => throw new WaivesApiException(), x => Responses.Success());
+
+            var sut = new ReliableRequestSender(
+                _retryLogger.RetryAction,
+                sender);
+
+            await sut.Send(_request);
+
+            Assert.True(_retryLogger.RetryActionCalled);
+        }
+
+        [Fact]
+        public async Task Send_calls_the_wrapped_request_sender_with_a_properly_cloned_request()
+        {
+            var request = ARequestWithContentAndHeader();
+
+            var sender = Substitute.For<IHttpRequestSender>();
+            sender.Send(Arg.Any<HttpRequestMessage>())
+                .Returns(Responses.Success());
+
+            var sut = new ReliableRequestSender(
+                _retryLogger.RetryAction,
+                sender);
+
+            await sut.Send(request);
+
+            await sender
+                .Received(1)
+                .Send(Arg.Any<HttpRequestMessage>());
+
+            await sender
+                .Received(1)
+                .Send(Arg.Is<HttpRequestMessage>(m =>
+                    RequestsAreEqual(request, m)));
+        }
+
+        private static HttpRequestMessage ARequestWithContentAndHeader()
+        {
+            return new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative))
+            {
+                Content = new StringContent("some content")
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                },
+                Properties =
+                {
+                    { "A property", "A property value"}
+                }
+            };
+        }
+
+        private bool RequestsAreEqual(HttpRequestMessage expectedRequest, HttpRequestMessage actualRequest)
+        {
+            Assert.Equal(expectedRequest.Method, actualRequest.Method);
+            Assert.Equal(expectedRequest.RequestUri, actualRequest.RequestUri);
+
+            Assert.Equal(expectedRequest.Headers, actualRequest.Headers);
+            Assert.Equal(expectedRequest.Properties, actualRequest.Properties);
+
+            var expectedContent = expectedRequest.Content.ReadAsByteArrayAsync().Result;
+            var actualContent = actualRequest.Content.ReadAsByteArrayAsync().Result;
+            Assert.True(expectedContent.SequenceEqual(actualContent));
+
+            return true;
+        }
+
+        private class RetryLogger
+        {
+            internal bool RetryActionCalled { get; private set; }
+
+            internal void RetryAction(DelegateResult<HttpResponseMessage> delegateResult, TimeSpan timeSpan, int counter, Context context)
+            {
+                RetryActionCalled = true;
+            }
+        }
+    }
+}

--- a/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/ReliableRequestSenderFacts.cs
@@ -76,23 +76,6 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
-        public async Task Send_retries_on_http_exception()
-        {
-            var sender = Substitute.For<IHttpRequestSender>();
-
-            sender.Send(Arg.Any<HttpRequestMessage>())
-                .Returns(x => throw new HttpRequestException(), x => Responses.Success());
-
-            var sut = new ReliableRequestSender(
-                _retryLogger.RetryAction,
-                sender);
-
-            await sut.Send(_request);
-
-            Assert.True(_retryLogger.RetryActionCalled);
-        }
-
-        [Fact]
         public async Task Send_retries_on_waives_api_exception()
         {
             var sender = Substitute.For<IHttpRequestSender>();


### PR DESCRIPTION
Closes #9 (Retry failed requests)

## Implementation approach
The existing `RequestSender` which made the requests using an `HttpClient` (and did some logging at the same time) has been supplemented by three decorators (in this order, bottom-up):
 * `ExceptionHandlingRequestSender`
 * `LoggingRequestSender`
 * `ReliableRequestSender`

The `ExceptionHandlingRequestSender` catches any exceptions thrown by `HttpClient` and wraps them in `WaivesApiException`s. This primarily includes the exceptions thrown if a request exceeds the `HttpClient`'s timeout.

The `LoggingRequestSender` takes the old logging responsibilities of `RequestSender`.

The `ReliableRequestSender` uses Polly and Polly Http Extensions to add a retry policy around request sending. The policy is an exponential back-off with jitter (to avoid multiple retried requests due to one event retrying at the same time). The total duration between retry attempts, if all retries happen, is just over 2 minutes.

Unfortunately because `HttpClient` doesn't allow the same `HttpRequestMessage` to be sent more than once, we have to clone the message before each `Send()`. This cloning code was taken from a Stack Overflow post here: [(https://stackoverflow.com/questions/18000583/re-send-httprequestmessage-exception)]. I'm a bit uneasy about this but empirically it seems reliable.

@phildrip has suggested a better approach of changing `IHttpRequestSender` to pass the components of the request and only construct the request itself in `RequestSender`. I will tackle that in a separate PR.

Currently the message logged when a retry is needed is a bit short of information. Specifically it doesn't include enough info to link it back to a failed request message in the logs. I'll improve this in a separate PR.

