### PR TITLE
Replace cloning of HttpRequestMessages with on-demand building of requests

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -36,7 +36,7 @@ namespace Waives.Http
 
         private async Task DoRead(Uri requestUri)
         {
-            var readRequest = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            var readRequest = new HttpRequestMessageTemplate(HttpMethod.Put, requestUri)
             {
                 Content = new StringContent(string.Empty)
             };
@@ -50,8 +50,8 @@ namespace Waives.Http
 
         private async Task<HttpContent> GetReadResults(Uri requestUri, string contentType)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-            request.Headers.Add("Accept", contentType);
+            var request = new HttpRequestMessageTemplate(HttpMethod.Get, requestUri);
+            request.Headers.Add(new KeyValuePair<string, string>("Accept", contentType));
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
@@ -66,7 +66,7 @@ namespace Waives.Http
         {
             var selfUrl = _behaviours["self"];
 
-            var request = new HttpRequestMessage(HttpMethod.Delete,
+            var request = new HttpRequestMessageTemplate(HttpMethod.Delete,
                 selfUrl.CreateUri());
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);
@@ -80,7 +80,7 @@ namespace Waives.Http
         {
             var classifyUrl = _behaviours["document:classify"];
 
-            var request = new HttpRequestMessage(HttpMethod.Post,
+            var request = new HttpRequestMessageTemplate(HttpMethod.Post,
                 classifyUrl.CreateUri(new
                 {
                     classifier_name = classifierName

--- a/src/Waives.Http/ExceptionHandlingRequestSender.cs
+++ b/src/Waives.Http/ExceptionHandlingRequestSender.cs
@@ -19,7 +19,7 @@ namespace Waives.Http
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
         {
             try
             {

--- a/src/Waives.Http/HttpRequestMessageBuilder.cs
+++ b/src/Waives.Http/HttpRequestMessageBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http;
+
+namespace Waives.Http
+{
+    internal static class HttpRequestMessageBuilder
+    {
+        public static HttpRequestMessage BuildRequest(HttpRequestMessageTemplate template)
+        {
+            var request = new HttpRequestMessage(template.Method, template.RequestUri)
+            {
+                Content = template.Content
+            };
+
+            foreach (var header in template.Headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+
+            return request;
+        }
+    }
+}

--- a/src/Waives.Http/HttpRequestMessageTemplate.cs
+++ b/src/Waives.Http/HttpRequestMessageTemplate.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 
 namespace Waives.Http
 {
-    public class HttpRequestMessageTemplate
+    internal class HttpRequestMessageTemplate
     {
         public HttpRequestMessageTemplate(HttpMethod method, Uri requestUri)
         {

--- a/src/Waives.Http/HttpRequestMessageTemplate.cs
+++ b/src/Waives.Http/HttpRequestMessageTemplate.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Waives.Http
+{
+    public class HttpRequestMessageTemplate
+    {
+        public HttpRequestMessageTemplate(HttpMethod method, Uri requestUri)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            RequestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
+            Headers = new List<KeyValuePair<string, string>>();
+        }
+
+        public HttpMethod Method { get; set; }
+        public Uri RequestUri { get; set; }
+        public HttpContent Content { get; set; }
+        public List<KeyValuePair<string, string>> Headers { get; }
+    }
+}

--- a/src/Waives.Http/IHttpRequestSender.cs
+++ b/src/Waives.Http/IHttpRequestSender.cs
@@ -5,6 +5,6 @@ namespace Waives.Http
 {
     internal interface IHttpRequestSender
     {
-        Task<HttpResponseMessage> Send(HttpRequestMessage request);
+        Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request);
     }
 }

--- a/src/Waives.Http/LoggingRequestSender.cs
+++ b/src/Waives.Http/LoggingRequestSender.cs
@@ -17,7 +17,7 @@ namespace Waives.Http
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
         {
             var stopWatch = new Stopwatch();
             Logger.Log(LogLevel.Trace, $"Sending {request.Method} request to {request.RequestUri}");

--- a/src/Waives.Http/ReliableRequestSender.cs
+++ b/src/Waives.Http/ReliableRequestSender.cs
@@ -26,21 +26,12 @@ namespace Waives.Http
             _wrappedRequestSender = wrappedRequestSender ?? throw new ArgumentNullException(nameof(wrappedRequestSender));
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
         {
             return await _policy
                 .ExecuteAsync(() =>
-                    SendClonedRequest(request))
+                    _wrappedRequestSender.Send(request))
                 .ConfigureAwait(false);
-        }
-
-        private async Task<HttpResponseMessage> SendClonedRequest(HttpRequestMessage request)
-        {
-            // HttpClient does not allow an HttpRequestMessage to be sent more than once,
-            // which would cause an issue if we retry, so clone the request first and send the
-            // clone to the wrapped sender.
-            var clonedRequest = await request.CloneAsync().ConfigureAwait(false);
-            return await _wrappedRequestSender.Send(clonedRequest).ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -22,15 +22,7 @@ namespace Waives.Http
 
         public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate template)
         {
-            var request = new HttpRequestMessage(template.Method, template.RequestUri)
-            {
-                Content = template.Content
-            };
-
-            foreach (var header in template.Headers)
-            {
-                request.Headers.Add(header.Key, header.Value);
-            }
+            var request = HttpRequestMessageBuilder.BuildRequest(template);
 
             return await _httpClient.SendAsync(request).ConfigureAwait(false);
         }

--- a/src/Waives.Http/RequestSender.cs
+++ b/src/Waives.Http/RequestSender.cs
@@ -20,8 +20,18 @@ namespace Waives.Http
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Waives.NET", productVersion));
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessage request)
+        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate template)
         {
+            var request = new HttpRequestMessage(template.Method, template.RequestUri)
+            {
+                Content = template.Content
+            };
+
+            foreach (var header in template.Headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+
             return await _httpClient.SendAsync(request).ConfigureAwait(false);
         }
     }

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -72,7 +72,7 @@ namespace Waives.Http
         public async Task<Document> CreateDocument(Stream documentSource)
         {
             var request =
-                new HttpRequestMessage(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
+                new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
                 {
                     Content = new StreamContent(documentSource)
                 };
@@ -83,7 +83,7 @@ namespace Waives.Http
         public async Task<Document> CreateDocument(string path)
         {
             var request =
-                new HttpRequestMessage(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
+                new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
                 {
                     Content = new StreamContent(File.OpenRead(path))
                 };
@@ -91,7 +91,7 @@ namespace Waives.Http
             return await CreateDocument(request).ConfigureAwait(false);
         }
 
-        private async Task<Document> CreateDocument(HttpRequestMessage request)
+        private async Task<Document> CreateDocument(HttpRequestMessageTemplate request)
         {
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             await EnsureSuccessStatus(response).ConfigureAwait(false);
@@ -108,7 +108,7 @@ namespace Waives.Http
 
         public async Task<Classifier> CreateClassifier(string name, string samplesPath = null)
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, new Uri($"/classifiers/{name}", UriKind.Relative));
+            var request = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/classifiers/{name}", UriKind.Relative));
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             await EnsureSuccessStatus(response).ConfigureAwait(false);
 
@@ -127,7 +127,7 @@ namespace Waives.Http
 
         public async Task<Classifier> GetClassifier(string name)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, new Uri($"/classifiers/{name}", UriKind.Relative));
+            var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri($"/classifiers/{name}", UriKind.Relative));
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             await EnsureSuccessStatus(response).ConfigureAwait(false);
 
@@ -139,7 +139,7 @@ namespace Waives.Http
 
         public async Task<IEnumerable<Document>> GetAllDocuments()
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+            var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             await EnsureSuccessStatus(response).ConfigureAwait(false);
 
@@ -151,7 +151,7 @@ namespace Waives.Http
         {
             Logger.Log(LogLevel.Debug, $"Authenticating with Waives at {HttpClient.BaseAddress}");
 
-            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("/oauth/token", UriKind.Relative))
+            var request = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri("/oauth/token", UriKind.Relative))
             {
                 Content = new FormUrlEncodedContent(new Dictionary<string, string>
                 {

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -47,14 +47,14 @@ namespace Waives.Http.Tests
         public async Task Delete_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success());
 
             await _sut.Delete();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Delete &&
                     m.RequestUri.ToString() == _selfUrl));
         }
@@ -63,7 +63,7 @@ namespace Waives.Http.Tests
         public async Task Delete_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage());
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Delete());
@@ -74,14 +74,14 @@ namespace Waives.Http.Tests
         public async Task Read_sends_read_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.GetReadResults(_readResultsContent));
 
             await _sut.Read(_readResultsFilename);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Put &&
                     m.RequestUri.ToString() == _readUrl));
         }
@@ -90,14 +90,14 @@ namespace Waives.Http.Tests
         public async Task Read_sends_get_read_results_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.GetReadResults(_readResultsContent));
 
             await _sut.Read(_readResultsFilename);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
                     m.RequestUri.ToString() == _readUrl));
         }
@@ -106,7 +106,7 @@ namespace Waives.Http.Tests
         public async Task Read_sends_get_read_results_request_with_specified_content_type()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.GetReadResults(_readResultsContent));
 
             var expectedContentType = "application/text";
@@ -115,32 +115,32 @@ namespace Waives.Http.Tests
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
-                    m.Headers.Accept.ToString() == expectedContentType));
+                    m.Headers.Contains(new KeyValuePair<string, string>("Accept", expectedContentType))));
         }
 
         [Fact]
         public async Task Read_gets_read_results_in_waives_format_if_content_type_is_not_specified()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.GetReadResults(_readResultsContent));
 
             await _sut.Read(_readResultsFilename);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
-                    m.Headers.Accept.ToString() == ContentTypes.WaivesReadResults));
+                    m.Headers.Contains(new KeyValuePair<string, string>("Accept", ContentTypes.WaivesReadResults))));
         }
 
         [Fact]
         public async Task Read_saves_contents_of_read_results_response_to_specified_file()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.GetReadResults(_readResultsContent));
 
             await _sut.Read(_readResultsFilename);
@@ -154,7 +154,7 @@ namespace Waives.Http.Tests
         public async Task Read_throws_if_read_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage(), Responses.GetReadResults(_readResultsContent));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
@@ -166,7 +166,7 @@ namespace Waives.Http.Tests
         public async Task Delete_throws_if_get_read_results_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success(), Responses.ErrorWithMessage());
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read(_readResultsFilename));
@@ -177,14 +177,14 @@ namespace Waives.Http.Tests
         public async Task Classify_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Classify());
 
             await _sut.Classify(_classifierName);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == _classifyUrl));
         }
@@ -193,7 +193,7 @@ namespace Waives.Http.Tests
         public async Task Classify_returns_a_result_with_correct_properties_set()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Classify());
 
             var result = await _sut.Classify(_classifierName);
@@ -210,7 +210,7 @@ namespace Waives.Http.Tests
         public async Task Classify_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage());
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Classify(_classifierName));

--- a/test/Waives.Http.Tests/ExceptionHandlingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/ExceptionHandlingRequestSenderFacts.cs
@@ -11,7 +11,7 @@ namespace Waives.Http.Tests
     public class ExceptionHandlingRequestSenderFacts
     {
         private readonly IHttpRequestSender _sender;
-        private readonly HttpRequestMessage _request;
+        private readonly HttpRequestMessageTemplate _request;
         private readonly ExceptionHandlingRequestSender _sut;
 
         public ExceptionHandlingRequestSenderFacts()
@@ -19,7 +19,7 @@ namespace Waives.Http.Tests
             _sender = Substitute.For<IHttpRequestSender>();
             _sut = new ExceptionHandlingRequestSender(_sender);
 
-            _request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+            _request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace Waives.Http.Tests
         {
             var expectedResponse = Responses.Success();
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(expectedResponse);
 
             var response = await _sut.Send(_request);
@@ -40,7 +40,7 @@ namespace Waives.Http.Tests
         public async Task Throws_WaivesApiException_if_wrapped_sender_times_out(Exception senderException)
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(senderException);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -52,7 +52,7 @@ namespace Waives.Http.Tests
         public async Task Includes_request_details_in_exception_if_wrapped_sender_times_out(Exception senderException)
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(senderException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -67,7 +67,7 @@ namespace Waives.Http.Tests
         {
             var expectedException = new Exception("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(expectedException);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -79,7 +79,7 @@ namespace Waives.Http.Tests
         {
             var expectedException = new Exception("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(expectedException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -93,7 +93,7 @@ namespace Waives.Http.Tests
         {
             var expectedException = new Exception("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(expectedException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>

--- a/test/Waives.Http.Tests/HttpRequestMessageBuilderFacts.cs
+++ b/test/Waives.Http.Tests/HttpRequestMessageBuilderFacts.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Xunit;
+
+namespace Waives.Http.Tests
+{
+    public class HttpRequestMessageBuilderFacts
+    {
+        [Theory]
+        [MemberData(nameof(TemplateInputs))]
+        public void Sets_method_and_uri_on_request(HttpMethod method, Uri uri)
+        {
+            var template = new HttpRequestMessageTemplate(
+                method,
+                uri);
+
+            var request = HttpRequestMessageBuilder.BuildRequest(template);
+
+            Assert.Equal(method, request.Method);
+            Assert.Equal(uri, request.RequestUri);
+        }
+
+        [Fact]
+        public void Sets_content_on_request()
+        {
+            const string expectedContents = "some contents";
+            var template = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri("/some-url", UriKind.Relative))
+            {
+                Content = new StringContent(expectedContents)
+            };
+
+            var request = HttpRequestMessageBuilder.BuildRequest(template);
+
+            var actualContents = request.Content.ReadAsStringAsync().Result;
+
+            Assert.Equal(expectedContents, actualContents);
+        }
+
+        [Fact]
+        public void Sets_headers_on_request()
+        {
+            const string headerKey = "Accept";
+            const string headerValue = "text/plain";
+
+            var template = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri("/some-url", UriKind.Relative));
+            template.Headers.Add(new KeyValuePair<string, string>(headerKey, headerValue));
+
+            var request = HttpRequestMessageBuilder.BuildRequest(template);
+
+            Assert.Single(request.Headers);
+        }
+
+
+        public static IEnumerable<object[]> TemplateInputs()
+        {
+            yield return new object[] {HttpMethod.Post, new Uri("/some-url", UriKind.Relative)};
+            yield return new object[] {HttpMethod.Get, new Uri("/another-url", UriKind.Relative)};
+        }
+    }
+}

--- a/test/Waives.Http.Tests/LoggingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/LoggingRequestSenderFacts.cs
@@ -13,7 +13,7 @@ namespace Waives.Http.Tests
         private readonly IHttpRequestSender _sender;
         private readonly ILogger _logger;
         private readonly LoggingRequestSender _sut;
-        private readonly HttpRequestMessage _request;
+        private readonly HttpRequestMessageTemplate _request;
 
         public LoggingRequestSenderFacts()
         {
@@ -21,7 +21,7 @@ namespace Waives.Http.Tests
             _logger = Substitute.For<ILogger>();
             _sut = new LoggingRequestSender(_sender, _logger);
 
-            _request = new HttpRequestMessage(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
+            _request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Waives.Http.Tests
         {
             var expectedResponse = Responses.Success();
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(expectedResponse);
 
             var response = await _sut.Send(_request);
@@ -42,7 +42,7 @@ namespace Waives.Http.Tests
         {
             var expectedException = new WaivesApiException();
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(expectedException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -55,7 +55,7 @@ namespace Waives.Http.Tests
         public async Task Logs_a_sending_request_message_when_request_is_successful()
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success());
 
             await _sut.Send(_request);
@@ -69,7 +69,7 @@ namespace Waives.Http.Tests
         {
             var exception = new WaivesApiException("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -83,7 +83,7 @@ namespace Waives.Http.Tests
         public async Task Logs_a_received_response_message_when_request_is_successful()
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.Success());
 
             await _sut.Send(_request);
@@ -97,7 +97,7 @@ namespace Waives.Http.Tests
         {
             var exception = new WaivesApiException("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -112,7 +112,7 @@ namespace Waives.Http.Tests
         {
             var exception = new WaivesApiException("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -129,7 +129,7 @@ namespace Waives.Http.Tests
             var exception = new WaivesApiException("an error message", innerException);
 
             _sender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -30,7 +30,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_sends_a_request_to_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.CreateDocument());
 
             using (var stream = new MemoryStream(_documentContents))
@@ -40,7 +40,7 @@ namespace Waives.Http.Tests
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == "/documents"));
         }
@@ -49,7 +49,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_sends_the_supplied_stream_as_content()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.CreateDocument());
 
             using (var stream = new MemoryStream(_documentContents))
@@ -58,7 +58,7 @@ namespace Waives.Http.Tests
 
                 await _requestSender
                     .Received(1)
-                    .Send(Arg.Is<HttpRequestMessage>(m =>
+                    .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                         RequestContentEquals(m, _documentContents)));
             }
         }
@@ -69,18 +69,18 @@ namespace Waives.Http.Tests
             const string filePath = "DummyDocument.txt";
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.CreateDocument());
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessage>(m => m.RequestUri.ToString().Contains("/classify")))
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m => m.RequestUri.ToString().Contains("/classify")))
                 .Returns(Responses.Classify());
 
             await _sut.CreateDocument(filePath);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     RequestContentEquals(m, File.ReadAllBytes(filePath))));
         }
 
@@ -88,7 +88,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_returns_a_document_that_can_be_used()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.CreateDocument());
 
             using (var stream = new MemoryStream(_documentContents))
@@ -98,13 +98,13 @@ namespace Waives.Http.Tests
                 Assert.Equal("expectedDocumentId", document.Id);
 
                 _requestSender
-                    .Send(Arg.Any<HttpRequestMessage>())
+                    .Send(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(Responses.Classify());
 
                 await document.Classify("classifier");
 
                 _requestSender
-                    .Send(Arg.Any<HttpRequestMessage>())
+                    .Send(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(Responses.Success());
 
                 await document.Delete();
@@ -115,7 +115,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage());
 
             using (var stream = new MemoryStream(_documentContents))
@@ -131,14 +131,14 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_sends_a_request_to_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.GetAllDocuments());
 
             await _sut.GetAllDocuments();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
                     m.RequestUri.ToString() == "/documents"));
         }
@@ -147,7 +147,7 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_returns_one_document_for_each_returned_by_the_API()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.GetAllDocuments());
 
             var documents = await _sut.GetAllDocuments();
@@ -161,7 +161,7 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage());
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -177,14 +177,14 @@ namespace Waives.Http.Tests
             const string expectedClientSecret = "clientsecret";
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.GetToken());
 
             await _sut.Login(expectedClientId, expectedClientSecret);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessage>(m =>
+                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     IsFormWithClientCredentials(m.Content, expectedClientId, expectedClientSecret)));
         }
@@ -193,7 +193,7 @@ namespace Waives.Http.Tests
         public async Task Login_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessage>())
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(Responses.ErrorWithMessage());
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -217,7 +217,7 @@ namespace Waives.Http.Tests
             return true;
         }
 
-        private bool RequestContentEquals(HttpRequestMessage request, byte[] expectedContents)
+        private bool RequestContentEquals(HttpRequestMessageTemplate request, byte[] expectedContents)
         {
             var actualRequestContents = request.Content.ReadAsByteArrayAsync().Result;
 


### PR DESCRIPTION
Starts with commit a791d70

In PR #31 the limitation of only being able to send an `HttpRequestMessage` once through the `HttpClient` led to us cloning the original request before trying to send it. However, we were uncomfortable with this code - it was pinched from an SO post and we didn't trust it.

In this change I've followed @phildrip's suggestion and changed `IHttpRequestSender` so we pass all the information required to build the request, rather than the request itself. We then build the `HttpRequestMessage` just before sending. 

The information required is packaged in an `HttpRequestMessageTemplate` (which looks suspiciously like an `HttpRequestMessage` for readability and minimum changes). The `HttpRequestMessageBuilder` then provides a method for building a request from this template.

It has occurred to me in writing this that the `HttpRequestMessageBuilder`  method could actually be a `ToRequest()` on the `HttpRequestMessageTemplate` but I'll let you take a look before doing anything with that.

---
Connects to #9.