### PR TITLE
Add extraction as pipeline operation

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -95,5 +95,24 @@ namespace Waives.Http
             var responseBody = await response.Content.ReadAsAsync<ClassificationResponse>().ConfigureAwait(false);
             return responseBody.ClassificationResults;
         }
+
+        public async Task<IEnumerable<ExtractionResult>> Extract(string extractorName)
+        {
+            var extractUrl = _behaviours["document:extract"];
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                extractUrl.CreateUri(new
+                {
+                    classifier_name = extractorName
+                }));
+
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new WaivesApiException($"Failed to extract data from the document using extractor '{extractorName}'");
+            }
+
+            var responseBody = await response.Content.ReadAsAsync<ExtractionResponse>().ConfigureAwait(false);
+            return responseBody.ExtractionResults;
+        }
     }
 }

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -96,7 +96,7 @@ namespace Waives.Http
             return responseBody.ClassificationResults;
         }
 
-        public async Task<IEnumerable<ExtractionResult>> Extract(string extractorName)
+        public async Task<ExtractionResponse> Extract(string extractorName)
         {
             var extractUrl = _behaviours["document:extract"];
             var request = new HttpRequestMessage(HttpMethod.Post,
@@ -112,7 +112,7 @@ namespace Waives.Http
             }
 
             var responseBody = await response.Content.ReadAsAsync<ExtractionResponse>().ConfigureAwait(false);
-            return responseBody.ExtractionResults;
+            return responseBody;
         }
     }
 }

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Waives.Http.Responses
+{
+    internal class ExtractionResponse
+    {
+        [JsonProperty("field_results")]
+        public IEnumerable<ExtractionResult> ExtractionResults { get; set; }
+
+        [JsonProperty("document")]
+        public ExtractionDocument DocumentMetadata { get; set; }
+    }
+
+    public class ExtractionResult
+    {
+        [JsonProperty("field_name")]
+        public string FieldName { get; set; }
+
+        [JsonProperty("rejected")]
+        public bool Rejected { get; set; }
+
+        [JsonProperty("reject_reason")]
+        public string RejectReason { get; set; }
+
+        [JsonProperty("result")]
+        public ExtractionResult Result { get; set; }
+
+        [JsonProperty("alternatives")]
+        public IEnumerable<ExtractionResult> AlternativeMatches { get; set; }
+
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        [JsonProperty("proximity_score")]
+        public string ProximityScore { get; set; }
+
+        [JsonProperty("match_score")]
+        public string MatchScore { get; set; }
+
+        [JsonProperty("text_score")]
+        public string TextScore { get; set; }
+
+        [JsonProperty("areas")]
+        public IEnumerable<ExtractionResultArea> ResultAreas { get; set; }
+    }
+
+    public class ExtractionResultArea
+    {
+        [JsonProperty("top")]
+        public double Top { get; set; }
+
+        [JsonProperty("left")]
+        public double Left { get; set; }
+
+        [JsonProperty("bottom")]
+        public double Bottom { get; set; }
+
+        [JsonProperty("right")]
+        public double Right { get; set; }
+
+        [JsonProperty("page_number")]
+        public int PageNumber { get; set; }
+    }
+
+    public class ExtractionDocument
+    {
+        [JsonProperty("page_count")]
+        public int PageCount { get; set; }
+
+        [JsonProperty("pages")]
+        public IEnumerable<ExtractionPage> Pages { get; set; }
+    }
+
+    public class ExtractionPage
+    {
+        [JsonProperty("page_number")]
+        public int PageNumber { get; set; }
+
+        [JsonProperty("width")]
+        public double Width { get; set; }
+
+        [JsonProperty("height")]
+        public double Height { get; set; }
+    }
+}

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json;
 
 namespace Waives.Http.Responses
 {
-    internal class ExtractionResponse
+    public class ExtractionResponse
     {
         [JsonProperty("field_results")]
         public IEnumerable<ExtractionResult> ExtractionResults { get; set; }
 
         [JsonProperty("document")]
-        public ExtractionDocument DocumentMetadata { get; set; }
+        public ExtractionDocumentMetadata DocumentMetadata { get; set; }
     }
 
     public class ExtractionResult
@@ -24,7 +24,7 @@ namespace Waives.Http.Responses
         public string RejectReason { get; set; }
 
         [JsonProperty("result")]
-        public ExtractionResult Result { get; set; }
+        public ExtractionResult FieldResult { get; set; }
 
         [JsonProperty("alternatives")]
         public IEnumerable<ExtractionResult> AlternativeMatches { get; set; }
@@ -36,13 +36,13 @@ namespace Waives.Http.Responses
         public string Value { get; set; }
 
         [JsonProperty("proximity_score")]
-        public string ProximityScore { get; set; }
+        public double ProximityScore { get; set; }
 
         [JsonProperty("match_score")]
-        public string MatchScore { get; set; }
+        public double MatchScore { get; set; }
 
         [JsonProperty("text_score")]
-        public string TextScore { get; set; }
+        public double TextScore { get; set; }
 
         [JsonProperty("areas")]
         public IEnumerable<ExtractionResultArea> ResultAreas { get; set; }
@@ -66,7 +66,7 @@ namespace Waives.Http.Responses
         public int PageNumber { get; set; }
     }
 
-    public class ExtractionDocument
+    public class ExtractionDocumentMetadata
     {
         [JsonProperty("page_count")]
         public int PageCount { get; set; }

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -12,7 +12,11 @@ namespace Waives.Pipelines.HttpAdapters
     internal interface IHttpDocument
     {
         Task<ClassificationResult> Classify(string classifierName);
+
+        Task<ExtractionResponse> Extract(string extractorName);
+
         Task Delete(Action afterDeletedAction);
+
         string Id { get; }
     }
 
@@ -36,6 +40,11 @@ namespace Waives.Pipelines.HttpAdapters
         public async Task<ClassificationResult> Classify(string classifierName)
         {
             return await _documentClient.Classify(classifierName).ConfigureAwait(false);
+        }
+
+        public async Task<ExtractionResponse> Extract(string extractorName)
+        {
+            return await _documentClient.Extract(extractorName).ConfigureAwait(false);
         }
 
         public async Task Delete(Action afterDeletedAction)

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -122,6 +122,24 @@ namespace Waives.Pipelines
         }
 
         /// <summary>
+        /// Extract data from documents using the specified extractor. The extractor must have
+        /// been created previously in your Waives account in order to be used here.
+        /// </summary>
+        /// <param name="extractorName">The name of the extractor to use.</param>
+        /// <returns>The modified <see cref="Pipeline"/>.</returns>
+        public Pipeline ExtractWith(string extractorName)
+        {
+            _pipeline = _pipeline.Process(async d =>
+            {
+                var document = await d.Extract(extractorName).ConfigureAwait(false);
+                _logger.Log(LogLevel.Info, $"Extracted data from document '{d.Source}");
+                return document;
+            }, _onDocumentError);
+
+            return this;
+        }
+
+        /// <summary>
         /// Run an arbitrary transform on each document, doing something with results for example
         /// </summary>
         /// <param name="func"></param>

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -26,11 +26,23 @@ namespace Waives.Pipelines
 
         public ClassificationResult ClassificationResults { get; private set; }
 
+        public ExtractionResponse ExtractionResults { get; private set; }
+
         public async Task<WaivesDocument> Classify(string classifierName)
         {
             return new WaivesDocument(Source, _waivesDocument)
             {
-                ClassificationResults = await _waivesDocument.Classify(classifierName).ConfigureAwait(false)
+                ClassificationResults = await _waivesDocument.Classify(classifierName).ConfigureAwait(false),
+                ExtractionResults = ExtractionResults
+            };
+        }
+
+        public async Task<WaivesDocument> Extract(string extractorName)
+        {
+            return new WaivesDocument(Source, _waivesDocument)
+            {
+                ClassificationResults = ClassificationResults,
+                ExtractionResults = await _waivesDocument.Extract(extractorName).ConfigureAwait(false)
             };
         }
 

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -272,6 +272,18 @@ namespace Waives.Http.Tests
             Assert.Equal(1, extractionResultArea.PageNumber);
         }
 
+        [Fact]
+        public async Task Extract_throws_if_response_is_not_success_code()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(Responses.ErrorWithMessage());
+
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Extract(_extractorName));
+            Assert.Equal($"Failed to extract data from the document using extractor '{_extractorName}'",
+                exception.Message);
+        }
+
         public void Dispose()
         {
             if (File.Exists(_readResultsFilename))

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -239,6 +239,39 @@ namespace Waives.Http.Tests
                     m.RequestUri.ToString() == _extractUrl));
         }
 
+        [Fact]
+        public async Task Extract_returns_a_result_with_correct_properties_set()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessage>())
+                .Returns(Responses.Extract());
+
+            var response = await _sut.Extract(_extractorName);
+
+
+            var extractionPage = response.DocumentMetadata.Pages.First();
+            Assert.Equal(1, response.DocumentMetadata.PageCount);
+            Assert.Equal(1, extractionPage.PageNumber);
+            Assert.Equal(611.0, extractionPage.Width);
+            Assert.Equal(1008.0, extractionPage.Height);
+
+            var extractionResult = response.ExtractionResults.First();
+            Assert.Equal("Amount", extractionResult.FieldName);
+            Assert.False(extractionResult.Rejected);
+            Assert.Equal("None", extractionResult.RejectReason);
+            Assert.Equal("$5.50", extractionResult.FieldResult.Text);
+            Assert.Equal(100.0, extractionResult.FieldResult.ProximityScore);
+            Assert.Equal(100.0, extractionResult.FieldResult.MatchScore);
+            Assert.Equal(100.0, extractionResult.FieldResult.TextScore);
+
+            var extractionResultArea = extractionResult.FieldResult.ResultAreas.First();
+            Assert.Equal(558.7115, extractionResultArea.Top);
+            Assert.Equal(276.48, extractionResultArea.Left);
+            Assert.Equal(571.1989, extractionResultArea.Bottom);
+            Assert.Equal(298.58, extractionResultArea.Right);
+            Assert.Equal(1, extractionResultArea.PageNumber);
+        }
+
         public void Dispose()
         {
             if (File.Exists(_readResultsFilename))

--- a/test/Waives.Http.Tests/Responses.cs
+++ b/test/Waives.Http.Tests/Responses.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace Waives.Http.Tests
@@ -83,6 +84,17 @@ namespace Waives.Http.Tests
                         Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
                     },
                 };
+        }
+
+        public static HttpResponseMessage Extract()
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ExtractResponse)
+                {
+                    Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+                }
+            };
         }
 
         private const string ClassifyResponse = @"{
@@ -205,5 +217,42 @@ namespace Waives.Http.Tests
 
         private const string ErrorResponse = @"{
 	        ""message"": """ + ErrorMessage + "\"}";
+
+        private const string ExtractResponse = @"{
+""field_results"": [
+{
+    ""field_name"": ""Amount"",
+    ""rejected"": false,
+    ""reject_reason"": ""None"",
+    ""result"": {
+        ""text"": ""$5.50"",
+        ""value"": null,
+        ""rejected"": false,
+        ""reject_reason"": ""None"",
+        ""proximity_score"": 100.0,
+        ""match_score"": 100.0,
+        ""text_score"": 100.0,
+        ""areas"": [
+        {
+            ""top"": 558.7115,
+            ""left"": 276.48,
+            ""bottom"": 571.1989,
+            ""right"": 298.58,
+            ""page_number"": 1
+        }]
+    },
+    ""alternatives"": null,
+    ""tabular_results"": null
+}],
+""document"": {
+    ""page_count"": 1,
+    ""pages"": [
+        {
+            ""page_number"": 1,
+            ""width"": 611.0,
+            ""height"": 1008.0
+        }]
+    }
+}";
     }
 }

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -129,6 +129,38 @@ namespace Waives.Pipelines.Tests
         }
 
         [Fact]
+        public void Results_are_preserved_when_performing_classification_and_extraction_in_the_same_pipeline()
+        {
+            var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);
+
+            _rateLimiter
+                .RateLimited(Arg.Any<IObservable<Document>>())
+                .Returns(source);
+
+            _sut
+                .WithDocumentsFrom(source)
+                .ClassifyWith(Generate.String())
+                .ExtractWith(Generate.String())
+                .Subscribe(t =>
+                {
+                    Assert.NotNull(t.ExtractionResults);
+                    Assert.NotNull(t.ClassificationResults);
+                });
+
+            // Extract and classify in opposite order to ensure the results
+            // are preserved in both directions
+            _sut
+                .WithDocumentsFrom(source)
+                .ExtractWith(Generate.String())
+                .ClassifyWith(Generate.String())
+                .Subscribe(t =>
+                {
+                    Assert.NotNull(t.ExtractionResults);
+                    Assert.NotNull(t.ClassificationResults);
+                });
+        }
+
+        [Fact]
         public void Then_invokes_the_supplied_Action()
         {
             var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);


### PR DESCRIPTION
### Implementation approach

I have defined a new operation to the HTTP client API for extraction, which accepts a simple string name argument specifying the extractor to use in the operation. 

A similar `ExtractWith()` operation has been added to the Pipelines API to support extraction operations as part of a processing pipeline. 

### Design considerations, assumptions

I've followed the same approach as for classification in both APIs, to ensure consistency above all else. There is a pipeline test in place to guarantee that results are preserved across classification and extraction operations.

### Further work

The Waives API will need to add a "document:extract" link to the Create and Get Document responses in order for this feature to work. 