### PR TITLE
Fix README Pipelines sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To get started with this API, simply:
 ```csharp
 // Define a pipeline that classifies each document and writes its classification
 // to the console. This will also authenticate with the Waives API.
-var pipeline = WaivesApi.CreatePipeline(new WaivesOptions
+var pipeline = await WaivesApi.CreatePipeline(new WaivesOptions
 {
     ClientId = "clientId",
     ClientSecret = "clientSecret"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To get started with this API:
 
 ```csharp
 var client = WaivesClient.Create();
-client.Login("clientId", "clientSecret");
+await client.Login("clientId", "clientSecret");
 
 try
 {


### PR DESCRIPTION
The `CreatePipeline()` call is now async, which was not reflected in the example here.