### PR TITLE
Add documentation to Waives.Http

### DIFF
--- a/src/Waives.Http/ContentTypes.cs
+++ b/src/Waives.Http/ContentTypes.cs
@@ -1,48 +1,119 @@
 ﻿namespace Waives.Http
 {
 #pragma warning disable CA1034 // Nested types should not be visible
+    /// <summary>
+    /// A convenience class offering quick access to a number of MIME type strings
+    /// supported by the Waives platform.
+    /// </summary>
     public static class ContentTypes
     {
-        public static readonly string Pdf = "application/pdf";
-        public static readonly string Text = "text/plain";
-        public static readonly string Html = "text/html";
+        /// <summary>
+        /// Gets the MIME type string for PDF files
+        /// </summary>
+        public static string Pdf { get; } = "application/pdf";
 
+        /// <summary>
+        /// Gets the MIME type string for plain text files
+        /// </summary>
+        public static string Text { get; } = "text/plain";
+
+        /// <summary>
+        /// Gets the MIME type string for HTML files
+        /// </summary>
+        public static string Html { get; } = "text/html";
+
+        /// <summary>
+        /// MIME types specific to images
+        /// </summary>
         public static class Image
         {
-            public static readonly string Bitmap = "image/bmp";
-            public static readonly string Jpeg = "image/jpeg";
-            public static readonly string Tiff = "image/tiff";
+            /// <summary>
+            /// Gets the MIME type string for Bitmap images
+            /// </summary>
+            public static string Bitmap { get; } = "image/bmp";
+
+            /// <summary>
+            /// Gets the MIME type string for JPEG images
+            /// </summary>
+            public static string Jpeg { get; } = "image/jpeg";
+
+            /// <summary>
+            /// Gets the MIME type string for TIFF images
+            /// </summary>
+            public static string Tiff { get; } = "image/tiff";
         }
 
+        /// <summary>
+        /// MIME types specific to Microsoft Office files
+        /// </summary>
         public static class MicrosoftOfficeOpenXml
         {
-            public static readonly string Word =
+            /// <summary>
+            /// Gets the MIME type string for Word files
+            /// </summary>
+            public static string Word { get; } =
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-            public static readonly string Spreadsheet =
+            /// <summary>
+            /// Gets the MIME type string for Excel files
+            /// </summary>
+            public static string Spreadsheet { get; } =
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-            public static readonly string Presentation =
-                "application/vnd.openxmlformats-officedocument..presentationml.presentation";
+            /// <summary>
+            /// Gets the MIME type string for PowerPoint files
+            /// </summary>
+            public static string Presentation { get; } =
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+            /// <summary>
+            /// Gets the MIME type string for legacy (pre-Office 2007) Word files
+            /// </summary>
+            public static string WordLegacy { get; } = "application/msword";
+
+            /// <summary>
+            /// Gets the MIME type string for legacy (pre-Office 2007) Excel files
+            /// </summary>
+            public static string SpreadsheetLegacy { get; } = "application/vnd.ms-excel";
+
+            /// <summary>
+            /// Gets the MIME type string for legacy (pre-Office 2007) PowerPoint files
+            /// </summary>
+            public static string PresentationLegacy { get; } = "application/vnd.ms-powerpoint";
         }
 
-        public static class MicrosoftOffice
-        {
-            public static readonly string Word = "application/msword";
-            public static readonly string Spreadsheet = "application/vnd.ms-excel";
-            public static readonly string Presentation = "application/vnd.ms-powerpoint";
-        }
-
+        /// <summary>
+        /// MIME types specific to email files
+        /// </summary>
         public static class Email
         {
+            /// <summary>
+            /// Gets the MIME type string for MIME-format (.eml) emails
+            /// </summary>
             // ReSharper disable once InconsistentNaming
-            public static readonly string MIME = "message/rfc822";
-            public static readonly string MSG = "application/vnd.ms-outlook";
+            public static string MIME { get; } = "message/rfc822";
+
+            /// <summary>
+            /// Gets the MIME type string for Outlook-format (.msg) emails
+            /// </summary>
+            // ReSharper disable once InconsistentNaming
+            public static string MSG { get; } = "application/vnd.ms-outlook";
         }
 
-        public static readonly string WaivesReadResults = "application/vnd.waives.resultformats.read+zip";
-        public static readonly string OctetStream = "application/octet-stream";
-        public static readonly string Zip = "application/zip";
+        /// <summary>
+        /// Gets the MIME type string for Waives document recognition (OCR) results
+        /// </summary>
+        public static string WaivesReadResults { get; } = "application/vnd.waives.resultformats.read+zip";
+
+        /// <summary>
+        /// Gets the MIME type string for indeterminate binary files
+        /// </summary>
+        public static string OctetStream { get; } = "application/octet-stream";
+
+        /// <summary>
+        /// Gets the MIME type string for ZIP archive files
+        /// </summary>
+        public static string Zip { get; } = "application/zip";
     }
 #pragma warning restore CA1034 // Nested types should not be visible
 }

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -7,10 +7,18 @@ using Waives.Http.Responses;
 
 namespace Waives.Http
 {
+    /// <summary>
+    /// A client for the Waives' Documents API. Instances can be obtained
+    /// via document operations on <see cref="WaivesClient"/>.
+    /// </summary>
     public class Document
     {
         private readonly IHttpRequestSender _requestSender;
         private readonly IDictionary<string, HalUri> _behaviours;
+
+        /// <summary>
+        /// Gets the string identifier of this document in the Waives platform.
+        /// </summary>
         public string Id { get; }
 
         internal Document(IHttpRequestSender requestSender, string id, IDictionary<string, HalUri> behaviours)
@@ -20,6 +28,9 @@ namespace Waives.Http
             Id = id ?? throw new ArgumentNullException(nameof(id));
         }
 
+        /// <summary>
+        /// Deletes this document in the Waives platform.
+        /// </summary>
         public async Task Delete()
         {
             var selfUrl = _behaviours["self"];
@@ -30,6 +41,12 @@ namespace Waives.Http
             await _requestSender.Send(request).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Performs classification on this document using the given classifer
+        /// name. The named classifier must already exist in the Waives platform.
+        /// </summary>
+        /// <param name="classifierName">The name of the classifier to use.</param>
+        /// <returns>The results of the classification operation.</returns>
         public async Task<ClassificationResult> Classify(string classifierName)
         {
             var classifyUrl = _behaviours["document:classify"];
@@ -45,6 +62,12 @@ namespace Waives.Http
             return responseBody.ClassificationResults;
         }
 
+        /// <summary>
+        /// Performs extraction on this document using the given extractor
+        /// name. The named extractor must already exist in the Waives platform.
+        /// </summary>
+        /// <param name="extractorName">The name of the extractor to use.</param>
+        /// <returns>The results of the extraction operation.</returns>
         public async Task<ExtractionResponse> Extract(string extractorName)
         {
             var extractUrl = _behaviours["document:extract"];

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -68,7 +68,7 @@ namespace Waives.Http
         /// </summary>
         /// <param name="extractorName">The name of the extractor to use.</param>
         /// <returns>The results of the extraction operation.</returns>
-        public async Task<ExtractionResponse> Extract(string extractorName)
+        public async Task<ExtractionResults> Extract(string extractorName)
         {
             var extractUrl = _behaviours["document:extract"];
             var request = new HttpRequestMessageTemplate(HttpMethod.Post,
@@ -78,7 +78,7 @@ namespace Waives.Http
                 }));
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);
-            var responseBody = await response.Content.ReadAsAsync<ExtractionResponse>().ConfigureAwait(false);
+            var responseBody = await response.Content.ReadAsAsync<ExtractionResults>().ConfigureAwait(false);
             return responseBody;
         }
     }

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -74,7 +74,7 @@ namespace Waives.Http
             var request = new HttpRequestMessageTemplate(HttpMethod.Post,
                 extractUrl.CreateUri(new
                 {
-                    classifier_name = extractorName
+                    extractor_name = extractorName
                 }));
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);

--- a/src/Waives.Http/Responses/ClassificationResponse.cs
+++ b/src/Waives.Http/Responses/ClassificationResponse.cs
@@ -25,7 +25,7 @@ namespace Waives.Http.Responses
     /// scenario, you may want to route this document for a person to review, or handle differently in some other way.
     /// </para>
     /// <para>In general, unconfident classifications indicate that the content of the document is substantially different
-    /// from any documents contained in your sample set.Therefore you may also wish to capture these documents, analyse them
+    /// from any documents contained in your sample set. Therefore you may also wish to capture these documents, analyse them
     /// and if appropriate add some to your samples and retrain your classifier.
     /// </para>
     /// </remarks>

--- a/src/Waives.Http/Responses/ClassificationResponse.cs
+++ b/src/Waives.Http/Responses/ClassificationResponse.cs
@@ -35,14 +35,14 @@ namespace Waives.Http.Responses
         /// Gets the document type that Waives believes the document to be.
         /// </summary>
         [JsonProperty("document_type")]
-        public string DocumentType { get; set; }
+        public string DocumentType { get; internal set; }
 
         /// <summary>
         /// Gets a value giving an indication of how confident Waives is that the
         /// document type is correct.
         /// </summary>
         [JsonProperty("relative_confidence")]
-        public decimal RelativeConfidence { get; set; }
+        public decimal RelativeConfidence { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether Waives is confident that document type
@@ -50,13 +50,13 @@ namespace Waives.Http.Responses
         /// value of <see cref="DocumentType"/>.
         /// </summary>
         [JsonProperty("is_confident")]
-        public bool IsConfident { get; set; }
+        public bool IsConfident { get; internal set; }
 
         /// <summary>
         /// Gets a collection of scores for each possible document type in the classifer.
         /// </summary>
         [JsonProperty("document_type_scores")]
-        public IEnumerable<DocumentTypeScore> DocumentTypeScores { get; set; }
+        public IEnumerable<DocumentTypeScore> DocumentTypeScores { get; internal set; }
     }
 
     /// <summary>
@@ -68,12 +68,12 @@ namespace Waives.Http.Responses
         /// Gets the document type associated with this score.
         /// </summary>
         [JsonProperty("document_type")]
-        public string DocumentType { get; set; }
+        public string DocumentType { get; internal set; }
 
         /// <summary>
         /// Gets the score associated with this document type.
         /// </summary>
         [JsonProperty("score")]
-        public decimal Score { get; set; }
+        public decimal Score { get; internal set; }
     }
 }

--- a/src/Waives.Http/Responses/ClassificationResponse.cs
+++ b/src/Waives.Http/Responses/ClassificationResponse.cs
@@ -12,26 +12,67 @@ namespace Waives.Http.Responses
         internal ClassificationResult ClassificationResults { get; set; }
     }
 
+    /// <summary>
+    /// Represents the results of a <see cref="Document.Classify"/> operation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In most cases, the <see cref="DocumentType"/> and <see cref="IsConfident"/> flags are the only ones you should use
+    /// in production.
+    /// </para>
+    /// <para>
+    /// If <see cref="IsConfident"/> is false, you should not trust <see cref="DocumentType"/>. Depending on your
+    /// scenario, you may want to route this document for a person to review, or handle differently in some other way.
+    /// </para>
+    /// <para>In general, unconfident classifications indicate that the content of the document is substantially different
+    /// from any documents contained in your sample set.Therefore you may also wish to capture these documents, analyse them
+    /// and if appropriate add some to your samples and retrain your classifier.
+    /// </para>
+    /// </remarks>
     public class ClassificationResult
     {
+        /// <summary>
+        /// Gets the document type that Waives believes the document to be.
+        /// </summary>
         [JsonProperty("document_type")]
         public string DocumentType { get; set; }
 
+        /// <summary>
+        /// Gets a value giving an indication of how confident Waives is that the
+        /// document type is correct.
+        /// </summary>
         [JsonProperty("relative_confidence")]
         public decimal RelativeConfidence { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether Waives is confident that document type
+        /// is correct. If the value is <c>false</c>, you should not trust the
+        /// value of <see cref="DocumentType"/>.
+        /// </summary>
         [JsonProperty("is_confident")]
         public bool IsConfident { get; set; }
 
+        /// <summary>
+        /// Gets a collection of scores for each possible document type in the classifer.
+        /// </summary>
         [JsonProperty("document_type_scores")]
         public IEnumerable<DocumentTypeScore> DocumentTypeScores { get; set; }
     }
 
+    /// <summary>
+    /// Represents a classification score for a given document type.
+    /// </summary>
     public class DocumentTypeScore
     {
+        /// <summary>
+        /// Gets the document type associated with this score.
+        /// </summary>
         [JsonProperty("document_type")]
         public string DocumentType { get; set; }
 
+        /// <summary>
+        /// Gets the score associated with this document type.
+        /// </summary>
         [JsonProperty("score")]
         public decimal Score { get; set; }
     }

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -12,7 +12,7 @@ namespace Waives.Http.Responses
         /// Gets the extraction results for the document.
         /// </summary>
         [JsonProperty("field_results")]
-        public IEnumerable<ExtractionResult> ExtractionResults { get; internal set; }
+        public IEnumerable<FieldResult> FieldResults { get; internal set; }
 
         /// <summary>
         /// Gets extraction-specific document metadata.
@@ -21,73 +21,76 @@ namespace Waives.Http.Responses
         public ExtractionDocumentMetadata DocumentMetadata { get; internal set; }
     }
 
+    public class FieldResult
+    {
+        /// <summary>
+        /// Gets the name of the field
+        /// </summary>
+        [JsonProperty("field_name")]
+        public string FieldName { get; internal set; }
+
+        /// <summary>
+        /// Gets a flag indicating whether the field results should be considered potentially invalid
+        /// </summary>
+        [JsonProperty("rejected")]
+        public bool Rejected { get; internal set; }
+
+        /// <summary>
+        /// Gets a message indicating the reason for rejection of the field
+        /// </summary>
+        [JsonProperty("reject_reason")]
+        public string RejectReason { get; internal set; }
+
+        /// <summary>
+        /// Gets the primary result for the field (null for a table field)
+        /// </summary>
+        [JsonProperty("result")]
+        public ExtractionResult Result { get; internal set; }
+
+        /// <summary>
+        /// Gets a collection of secondary (alternative) results for the field
+        /// </summary>
+        [JsonProperty("alternatives")]
+        public IEnumerable<ExtractionResult> Alternatives { get; internal set; }
+    }
+
     /// <summary>
     /// Represents an individual extraction result.
     /// </summary>
     public class ExtractionResult
     {
         /// <summary>
-        /// Gets the field name for this extraction result.
-        /// </summary>
-        [JsonProperty("field_name")]
-        public string FieldName { get; internal set; }
-
-        /// <summary>
-        /// Gets a flag indicating whether or not this extraction result was rejected.
-        /// </summary>
-        [JsonProperty("rejected")]
-        public bool Rejected { get; internal set; }
-
-        /// <summary>
-        /// Gets a message indicating why this extraction result was rejected.
-        /// </summary>
-        [JsonProperty("reject_reason")]
-        public string RejectReason { get; internal set; }
-
-        /// <summary>
-        /// Gets the field value for this extraction result.
-        /// </summary>
-        [JsonProperty("result")]
-        public ExtractionResult FieldResult { get; internal set; }
-
-        /// <summary>
-        /// Gets a collection of alternative extraction results for this field.
-        /// </summary>
-        [JsonProperty("alternatives")]
-        public IEnumerable<ExtractionResult> AlternativeMatches { get; internal set; }
-
-        /// <summary>
-        /// Gets the document text matching this extraction result
+        /// Gets the text of the result
         /// </summary>
         [JsonProperty("text")]
         public string Text { get; internal set; }
 
         /// <summary>
-        /// Gets the value of this extraction result
+        /// Gets the value of the result as a non-text type (e.g. Decimal or DateTime), if available
         /// </summary>
         [JsonProperty("value")]
         public string Value { get; internal set; }
 
         /// <summary>
-        ///
+        /// Gets a score indicating how well any proximity rules have been met
         /// </summary>
         [JsonProperty("proximity_score")]
         public double ProximityScore { get; internal set; }
 
         /// <summary>
-        ///
+        /// Gets a score indicating how well the text matched any search criteria
         /// </summary>
         [JsonProperty("match_score")]
         public double MatchScore { get; internal set; }
 
         /// <summary>
-        ///
+        /// Gets a score indicating the OCR confidence assigned to the actual text that was extracted
         /// </summary>
         [JsonProperty("text_score")]
         public double TextScore { get; internal set; }
 
         /// <summary>
-        ///
+        /// Gets a list of areas from which the result originated
         /// </summary>
         [JsonProperty("areas")]
         public IEnumerable<ExtractionResultArea> ResultAreas { get; internal set; }

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -6,84 +6,84 @@ namespace Waives.Http.Responses
     public class ExtractionResponse
     {
         [JsonProperty("field_results")]
-        public IEnumerable<ExtractionResult> ExtractionResults { get; set; }
+        public IEnumerable<ExtractionResult> ExtractionResults { get; internal set; }
 
         [JsonProperty("document")]
-        public ExtractionDocumentMetadata DocumentMetadata { get; set; }
+        public ExtractionDocumentMetadata DocumentMetadata { get; internal set; }
     }
 
     public class ExtractionResult
     {
         [JsonProperty("field_name")]
-        public string FieldName { get; set; }
+        public string FieldName { get; internal set; }
 
         [JsonProperty("rejected")]
-        public bool Rejected { get; set; }
+        public bool Rejected { get; internal set; }
 
         [JsonProperty("reject_reason")]
-        public string RejectReason { get; set; }
+        public string RejectReason { get; internal set; }
 
         [JsonProperty("result")]
-        public ExtractionResult FieldResult { get; set; }
+        public ExtractionResult FieldResult { get; internal set; }
 
         [JsonProperty("alternatives")]
-        public IEnumerable<ExtractionResult> AlternativeMatches { get; set; }
+        public IEnumerable<ExtractionResult> AlternativeMatches { get; internal set; }
 
         [JsonProperty("text")]
-        public string Text { get; set; }
+        public string Text { get; internal set; }
 
         [JsonProperty("value")]
-        public string Value { get; set; }
+        public string Value { get; internal set; }
 
         [JsonProperty("proximity_score")]
-        public double ProximityScore { get; set; }
+        public double ProximityScore { get; internal set; }
 
         [JsonProperty("match_score")]
-        public double MatchScore { get; set; }
+        public double MatchScore { get; internal set; }
 
         [JsonProperty("text_score")]
-        public double TextScore { get; set; }
+        public double TextScore { get; internal set; }
 
         [JsonProperty("areas")]
-        public IEnumerable<ExtractionResultArea> ResultAreas { get; set; }
+        public IEnumerable<ExtractionResultArea> ResultAreas { get; internal set; }
     }
 
     public class ExtractionResultArea
     {
         [JsonProperty("top")]
-        public double Top { get; set; }
+        public double Top { get; internal set; }
 
         [JsonProperty("left")]
-        public double Left { get; set; }
+        public double Left { get; internal set; }
 
         [JsonProperty("bottom")]
-        public double Bottom { get; set; }
+        public double Bottom { get; internal set; }
 
         [JsonProperty("right")]
-        public double Right { get; set; }
+        public double Right { get; internal set; }
 
         [JsonProperty("page_number")]
-        public int PageNumber { get; set; }
+        public int PageNumber { get; internal set; }
     }
 
     public class ExtractionDocumentMetadata
     {
         [JsonProperty("page_count")]
-        public int PageCount { get; set; }
+        public int PageCount { get; internal set; }
 
         [JsonProperty("pages")]
-        public IEnumerable<ExtractionPage> Pages { get; set; }
+        public IEnumerable<ExtractionPage> Pages { get; internal set; }
     }
 
     public class ExtractionPage
     {
         [JsonProperty("page_number")]
-        public int PageNumber { get; set; }
+        public int PageNumber { get; internal set; }
 
         [JsonProperty("width")]
-        public double Width { get; set; }
+        public double Width { get; internal set; }
 
         [JsonProperty("height")]
-        public double Height { get; set; }
+        public double Height { get; internal set; }
     }
 }

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -3,86 +3,170 @@ using Newtonsoft.Json;
 
 namespace Waives.Http.Responses
 {
+    /// <summary>
+    /// Represents an extraction result response.
+    /// </summary>
     public class ExtractionResponse
     {
+        /// <summary>
+        /// Gets the extraction results for the document.
+        /// </summary>
         [JsonProperty("field_results")]
         public IEnumerable<ExtractionResult> ExtractionResults { get; internal set; }
 
+        /// <summary>
+        /// Gets extraction-specific document metadata.
+        /// </summary>
         [JsonProperty("document")]
         public ExtractionDocumentMetadata DocumentMetadata { get; internal set; }
     }
 
+    /// <summary>
+    /// Represents an individual extraction result.
+    /// </summary>
     public class ExtractionResult
     {
+        /// <summary>
+        /// Gets the field name for this extraction result.
+        /// </summary>
         [JsonProperty("field_name")]
         public string FieldName { get; internal set; }
 
+        /// <summary>
+        /// Gets a flag indicating whether or not this extraction result was rejected.
+        /// </summary>
         [JsonProperty("rejected")]
         public bool Rejected { get; internal set; }
 
+        /// <summary>
+        /// Gets a message indicating why this extraction result was rejected.
+        /// </summary>
         [JsonProperty("reject_reason")]
         public string RejectReason { get; internal set; }
 
+        /// <summary>
+        /// Gets the field value for this extraction result.
+        /// </summary>
         [JsonProperty("result")]
         public ExtractionResult FieldResult { get; internal set; }
 
+        /// <summary>
+        /// Gets a collection of alternative extraction results for this field.
+        /// </summary>
         [JsonProperty("alternatives")]
         public IEnumerable<ExtractionResult> AlternativeMatches { get; internal set; }
 
+        /// <summary>
+        /// Gets the document text matching this extraction result
+        /// </summary>
         [JsonProperty("text")]
         public string Text { get; internal set; }
 
+        /// <summary>
+        /// Gets the value of this extraction result
+        /// </summary>
         [JsonProperty("value")]
         public string Value { get; internal set; }
 
+        /// <summary>
+        ///
+        /// </summary>
         [JsonProperty("proximity_score")]
         public double ProximityScore { get; internal set; }
 
+        /// <summary>
+        ///
+        /// </summary>
         [JsonProperty("match_score")]
         public double MatchScore { get; internal set; }
 
+        /// <summary>
+        ///
+        /// </summary>
         [JsonProperty("text_score")]
         public double TextScore { get; internal set; }
 
+        /// <summary>
+        ///
+        /// </summary>
         [JsonProperty("areas")]
         public IEnumerable<ExtractionResultArea> ResultAreas { get; internal set; }
     }
 
+    /// <summary>
+    /// Represents the area on a page where an extraction result occurs.
+    /// </summary>
     public class ExtractionResultArea
     {
+        /// <summary>
+        /// Gets the top boundary of the extraction result area.
+        /// </summary>
         [JsonProperty("top")]
         public double Top { get; internal set; }
 
+        /// <summary>
+        /// Gets the left boundary of the extraction result area.
+        /// </summary>
         [JsonProperty("left")]
         public double Left { get; internal set; }
 
+        /// <summary>
+        /// Gets the bottom boundary of the extraction result area.
+        /// </summary>
         [JsonProperty("bottom")]
         public double Bottom { get; internal set; }
 
+        /// <summary>
+        /// Gets the right boundary of the extraction result area.
+        /// </summary>
         [JsonProperty("right")]
         public double Right { get; internal set; }
 
+        /// <summary>
+        /// Gets the page number where the extraction result appears.
+        /// </summary>
         [JsonProperty("page_number")]
         public int PageNumber { get; internal set; }
     }
 
+    /// <summary>
+    /// Provides access to extraction-specific metadata on a document.
+    /// </summary>
     public class ExtractionDocumentMetadata
     {
+        /// <summary>
+        /// Gets the number of pages in a document.
+        /// </summary>
         [JsonProperty("page_count")]
         public int PageCount { get; internal set; }
 
+        /// <summary>
+        /// Gets a collection of all the pages' metadata for a document.
+        /// </summary>
         [JsonProperty("pages")]
         public IEnumerable<ExtractionPage> Pages { get; internal set; }
     }
 
+    /// <summary>
+    /// Provides access to extraction-specific metadata on a document's page.
+    /// </summary>
     public class ExtractionPage
     {
+        /// <summary>
+        /// Gets the page number of the page.
+        /// </summary>
         [JsonProperty("page_number")]
         public int PageNumber { get; internal set; }
 
+        /// <summary>
+        /// Gets the width of the page.
+        /// </summary>
         [JsonProperty("width")]
         public double Width { get; internal set; }
 
+        /// <summary>
+        /// Gets the height of the page.
+        /// </summary>
         [JsonProperty("height")]
         public double Height { get; internal set; }
     }

--- a/src/Waives.Http/Responses/ExtractionResponse.cs
+++ b/src/Waives.Http/Responses/ExtractionResponse.cs
@@ -93,7 +93,7 @@ namespace Waives.Http.Responses
         /// Gets a list of areas from which the result originated
         /// </summary>
         [JsonProperty("areas")]
-        public IEnumerable<ExtractionResultArea> ResultAreas { get; internal set; }
+        public IEnumerable<ExtractionResultArea> Areas { get; internal set; }
     }
 
     /// <summary>

--- a/src/Waives.Http/Responses/ExtractionResults.cs
+++ b/src/Waives.Http/Responses/ExtractionResults.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Waives.Http.Responses
@@ -69,7 +70,7 @@ namespace Waives.Http.Responses
         /// Gets the value of the result as a non-text type (e.g. Decimal or DateTime), if available
         /// </summary>
         [JsonProperty("value")]
-        public string Value { get; internal set; }
+        public Object Value { get; internal set; }
 
         /// <summary>
         /// Gets a score indicating how well any proximity rules have been met

--- a/src/Waives.Http/Responses/ExtractionResults.cs
+++ b/src/Waives.Http/Responses/ExtractionResults.cs
@@ -6,7 +6,7 @@ namespace Waives.Http.Responses
     /// <summary>
     /// Represents an extraction result response.
     /// </summary>
-    public class ExtractionResponse
+    public class ExtractionResults
     {
         /// <summary>
         /// Gets the extraction results for the document.

--- a/src/Waives.Http/WaivesApiException.cs
+++ b/src/Waives.Http/WaivesApiException.cs
@@ -2,16 +2,23 @@ using System;
 
 namespace Waives.Http
 {
+    /// <inheritdoc />
+    /// <summary>
+    /// Represents an error occurring in calling the Waives platform API
+    /// </summary>
     public class WaivesApiException : Exception
     {
+        /// <inheritdoc />
         public WaivesApiException()
         {
         }
 
+        /// <inheritdoc />
         public WaivesApiException(string message) : base(message)
         {
         }
 
+        /// <inheritdoc />
         public WaivesApiException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -13,7 +13,7 @@ namespace Waives.Pipelines.HttpAdapters
     {
         Task<ClassificationResult> Classify(string classifierName);
 
-        Task<ExtractionResponse> Extract(string extractorName);
+        Task<ExtractionResults> Extract(string extractorName);
 
         Task Delete(Action afterDeletedAction);
 
@@ -42,7 +42,7 @@ namespace Waives.Pipelines.HttpAdapters
             return await _documentClient.Classify(classifierName).ConfigureAwait(false);
         }
 
-        public async Task<ExtractionResponse> Extract(string extractorName)
+        public async Task<ExtractionResults> Extract(string extractorName)
         {
             return await _documentClient.Extract(extractorName).ConfigureAwait(false);
         }

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -26,7 +26,7 @@ namespace Waives.Pipelines
 
         public ClassificationResult ClassificationResults { get; private set; }
 
-        public ExtractionResponse ExtractionResults { get; private set; }
+        public ExtractionResults ExtractionResults { get; private set; }
 
         public async Task<WaivesDocument> Classify(string classifierName)
         {

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -31,6 +31,10 @@ namespace Waives.Http.Tests
             _extractorName = "extractor";
 
             var readUrl = $"/documents/{documentId}/reads";
+
+            var templatedClassifyUrl = $"/documents/{documentId}/classify/" + "{classifier_name}";
+            var templatedExtractUrl = $"/documents/{documentId}/extract/" + "{extractor_name}";
+
             _classifyUrl = $"/documents/{documentId}/classify/{_classifierName}";
             _extractUrl = $"/documents/{documentId}/extract/{_extractorName}";
             _selfUrl = $"/documents/{documentId}";
@@ -38,8 +42,8 @@ namespace Waives.Http.Tests
             IDictionary<string, HalUri> behaviours = new Dictionary<string, HalUri>
             {
                 { "document:read", new HalUri(new Uri(readUrl, UriKind.Relative), false) },
-                { "document:classify", new HalUri(new Uri(_classifyUrl, UriKind.Relative), true) },
-                { "document:extract", new HalUri(new Uri(_extractUrl, UriKind.Relative), true) },
+                { "document:classify", new HalUri(new Uri(templatedClassifyUrl, UriKind.Relative), true) },
+                { "document:extract", new HalUri(new Uri(templatedExtractUrl, UriKind.Relative), true) },
                 { "self", new HalUri(new Uri(_selfUrl, UriKind.Relative), false) }
             };
 

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -167,7 +167,7 @@ namespace Waives.Http.Tests
             Assert.Equal(100.0, primaryResult.MatchScore);
             Assert.Equal(100.0, primaryResult.TextScore);
 
-            var primaryResultArea = primaryResult.ResultAreas.First();
+            var primaryResultArea = primaryResult.Areas.First();
             Assert.Equal(558.7115, primaryResultArea.Top);
             Assert.Equal(276.48, primaryResultArea.Left);
             Assert.Equal(571.1989, primaryResultArea.Bottom);
@@ -177,7 +177,7 @@ namespace Waives.Http.Tests
             var firstAlternativeResult = fieldResult.Alternatives.First();
             Assert.Equal("$10.50", firstAlternativeResult.Text);
 
-            var firstAlternativeResultArea = firstAlternativeResult.ResultAreas.First();
+            var firstAlternativeResultArea = firstAlternativeResult.Areas.First();
             Assert.Equal(123.4567, firstAlternativeResultArea.Top);
         }
 

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -150,26 +150,35 @@ namespace Waives.Http.Tests
 
 
             var extractionPage = response.DocumentMetadata.Pages.First();
+
             Assert.Equal(1, response.DocumentMetadata.PageCount);
             Assert.Equal(1, extractionPage.PageNumber);
             Assert.Equal(611.0, extractionPage.Width);
             Assert.Equal(1008.0, extractionPage.Height);
 
-            var extractionResult = response.ExtractionResults.First();
-            Assert.Equal("Amount", extractionResult.FieldName);
-            Assert.False(extractionResult.Rejected);
-            Assert.Equal("None", extractionResult.RejectReason);
-            Assert.Equal("$5.50", extractionResult.FieldResult.Text);
-            Assert.Equal(100.0, extractionResult.FieldResult.ProximityScore);
-            Assert.Equal(100.0, extractionResult.FieldResult.MatchScore);
-            Assert.Equal(100.0, extractionResult.FieldResult.TextScore);
+            var fieldResult = response.FieldResults.First();
+            Assert.Equal("Amount", fieldResult.FieldName);
+            Assert.False(fieldResult.Rejected);
+            Assert.Equal("None", fieldResult.RejectReason);
 
-            var extractionResultArea = extractionResult.FieldResult.ResultAreas.First();
-            Assert.Equal(558.7115, extractionResultArea.Top);
-            Assert.Equal(276.48, extractionResultArea.Left);
-            Assert.Equal(571.1989, extractionResultArea.Bottom);
-            Assert.Equal(298.58, extractionResultArea.Right);
-            Assert.Equal(1, extractionResultArea.PageNumber);
+            var primaryResult = fieldResult.Result;
+            Assert.Equal("$5.50", primaryResult.Text);
+            Assert.Equal(100.0, primaryResult.ProximityScore);
+            Assert.Equal(100.0, primaryResult.MatchScore);
+            Assert.Equal(100.0, primaryResult.TextScore);
+
+            var primaryResultArea = primaryResult.ResultAreas.First();
+            Assert.Equal(558.7115, primaryResultArea.Top);
+            Assert.Equal(276.48, primaryResultArea.Left);
+            Assert.Equal(571.1989, primaryResultArea.Bottom);
+            Assert.Equal(298.58, primaryResultArea.Right);
+            Assert.Equal(1, primaryResultArea.PageNumber);
+
+            var firstAlternativeResult = fieldResult.Alternatives.First();
+            Assert.Equal("$10.50", firstAlternativeResult.Text);
+
+            var firstAlternativeResultArea = firstAlternativeResult.ResultAreas.First();
+            Assert.Equal(123.4567, firstAlternativeResultArea.Top);
         }
 
         [Fact]

--- a/test/Waives.Http.Tests/RequestHandling/Response.cs
+++ b/test/Waives.Http.Tests/RequestHandling/Response.cs
@@ -275,7 +275,25 @@ namespace Waives.Http.Tests.RequestHandling
             ""page_number"": 1
         }]
     },
-    ""alternatives"": null,
+    ""alternatives"": [
+    {
+            ""text"": ""$10.50"",
+            ""value"": null,
+            ""rejected"": false,
+            ""reject_reason"": ""None"",
+            ""proximity_score"": 100.0,
+            ""match_score"": 100.0,
+            ""text_score"": 100.0,
+            ""areas"": [
+            {
+                ""top"": 123.4567,
+                ""left"": 276.48,
+                ""bottom"": 571.1989,
+                ""right"": 298.58,
+                ""page_number"": 1
+            }]
+        }
+    ],
     ""tabular_results"": null
 }],
 ""document"": {

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -22,7 +22,7 @@ namespace Waives.Pipelines.Tests
         {
             var httpDocument = Substitute.For<IHttpDocument>();
             httpDocument.Classify(Arg.Any<string>()).Returns(new ClassificationResult());
-            httpDocument.Extract(Arg.Any<string>()).Returns(new ExtractionResponse());
+            httpDocument.Extract(Arg.Any<string>()).Returns(new ExtractionResults());
             httpDocument.Delete(Arg.Invoke());
 
             _documentFactory


### PR DESCRIPTION
Fixes #36.

I have added documentation to all the "top-level" public types in Waives.Http; still to do are the various publicly-accessible response/result types.

I have also converted `ContentTypes` to expose a set of properties rather than fields.

Update (MW): 
In the course of completing the xml doc comments I found four issues, which this PR now also fixes:
 * The extraction results had "lost" a level. Somehow the properties for `FieldResult` and `ExtractionResult` had become conflated. I've separated these back out and tested that they are populated correctly from the live API
 * Extraction was completely broken. I think through a recent refactoring. The `Extract()` method was trying to inject the wrong value into the templated URI, and the test was not actually testing what we thought it was so didn't catch it
 * There was an inconsistency between names of results classes between classification and extraction. We had `ClassificationResult` and `ExtractionResponse`. The types are now `ClassificationResult` and `ExtractionResults` (which contains multiple `ExtractionResult`s)
 * The `ExtractionResult.Value` property was a `string` when it should be an `object`