### PR TITLE
Add support to Waives.Http for the Get Document operation

### DIFF
--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -96,6 +96,20 @@ namespace Waives.Http
             return await CreateDocument(File.OpenRead(path)).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Fetch a reference for the given document in the Waives platform.
+        /// </summary>
+        /// <param name="id">The ID of the document, as returned by <see cref="CreateDocument(Stream)"/>.</param>
+        /// <returns>A <see cref="Document"/> client for the specified document ID.</returns>
+        public async Task<Document> GetDocument(string id)
+        {
+            var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri($"/documents/{id}", UriKind.Relative));
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
+
+            var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
+            return new Document(_requestSender, responseContent.Id, responseContent.Links);
+        }
+
         public async Task<IEnumerable<Document>> GetAllDocuments()
         {
             var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -55,6 +55,25 @@ namespace Waives.Http
             set => _requestSender.Timeout = value;
         }
 
+        public async Task Login(string clientId, string clientSecret)
+        {
+            var request = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri("/oauth/token", UriKind.Relative))
+            {
+                Content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    {"client_id", clientId},
+                    {"client_secret", clientSecret}
+                })
+            };
+
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
+
+            var responseContent = await response.Content.ReadAsAsync<AccessToken>().ConfigureAwait(false);
+            var accessToken = responseContent.Token;
+
+            _requestSender.Authenticate(accessToken);
+        }
+
         public async Task<Document> CreateDocument(Stream documentSource)
         {
             var request =
@@ -84,25 +103,6 @@ namespace Waives.Http
 
             var responseContent = await response.Content.ReadAsAsync<DocumentCollection>().ConfigureAwait(false);
             return responseContent.Documents.Select(d => new Document(_requestSender, d.Id, d.Links));
-        }
-
-        public async Task Login(string clientId, string clientSecret)
-        {
-            var request = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri("/oauth/token", UriKind.Relative))
-            {
-                Content = new FormUrlEncodedContent(new Dictionary<string, string>
-                {
-                    {"client_id", clientId},
-                    {"client_secret", clientSecret}
-                })
-            };
-
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
-
-            var responseContent = await response.Content.ReadAsAsync<AccessToken>().ConfigureAwait(false);
-            var accessToken = responseContent.Token;
-
-            _requestSender.Authenticate(accessToken);
         }
     }
 }

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -63,31 +63,18 @@ namespace Waives.Http
                     Content = new StreamContent(documentSource)
                 };
 
-            return await CreateDocument(request).ConfigureAwait(false);
-        }
-
-        public async Task<Document> CreateDocument(string path)
-        {
-            var request =
-                new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
-                {
-                    Content = new StreamContent(File.OpenRead(path))
-                };
-
-            return await CreateDocument(request).ConfigureAwait(false);
-        }
-
-        private async Task<Document> CreateDocument(HttpRequestMessageTemplate request)
-        {
             var response = await _requestSender.Send(request).ConfigureAwait(false);
 
             var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
             var id = responseContent.Id;
             var behaviours = responseContent.Links;
 
-            var document = new Document(_requestSender, id, behaviours);
+            return new Document(_requestSender, id, behaviours);
+        }
 
-            return document;
+        public async Task<Document> CreateDocument(string path)
+        {
+            return await CreateDocument(File.OpenRead(path)).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Document>> GetAllDocuments()

--- a/test/Waives.Http.Tests/RequestHandling/Response.cs
+++ b/test/Waives.Http.Tests/RequestHandling/Response.cs
@@ -58,6 +58,14 @@ namespace Waives.Http.Tests.RequestHandling
             });
         }
 
+        public static HttpResponseMessage GetDocument(HttpRequestMessageTemplate requestTemplate)
+        {
+            return From(HttpStatusCode.OK, requestTemplate, new StringContent(GetDocumentResponse)
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+            });
+        }
+
         public static HttpResponseMessage GetAllDocuments(HttpRequestMessageTemplate requestTemplate)
         {
             return From(HttpStatusCode.OK, requestTemplate, new StringContent(GetAllDocumentsResponse)
@@ -159,6 +167,31 @@ namespace Waives.Http.Tests.RequestHandling
                 }]
             }
         }";
+
+        private const string GetDocumentResponse = @"{
+    ""id"": ""expectedDocumentId1"",
+    ""_links"": {
+        ""document:read"": {
+            ""href"": ""/documents/expectedDocumentId1/reads""
+        },
+        ""document:classify"": {
+            ""href"": ""/documents/expectedDocumentId1/classify/{classifier_name}"",
+            ""templated"": true
+        },
+        ""self"": {
+            ""href"": ""/documents/expectedDocumentId1""
+        }
+    },
+    ""_embedded"": {
+        ""files"": [
+        {
+            ""id"": ""HEE7UnX680y7yecR-yXsPA"",
+            ""file_type"": ""Image:TIFF"",
+            ""size"": 41203,
+            ""sha256"": ""eeea8dbbf4f0da70bf3dcc25ee0ecf5c6f8a4eae2817fe782a59589cbd4cb9fd""
+        }]
+    }
+}";
 
         private const string GetAllDocumentsResponse = @"{
 	        ""documents"": [


### PR DESCRIPTION
### Implementation approach

In order to allow deletion of an individual document where the ID has been cached but the `Document` instance is no longer around, we need to provide the ability to retrieve the document prior to deletion. This PR adds support to Waives.Http for the Get Document operation, invoked as `client.GetDocument("documentId")`. 

### Design considerations, assumptions

I considered supporting a sort of "force delete" operation on `WaivesClient`, which you give a document ID for the method call to delete, but I can't find a satisfactory way of implementing this. Options I considered are:

* **Add a `DeleteDocument()` method to `WaivesClient`.** This is undesirable because it duplicates the `Document.Delete()` method too closely, and I suspect will be used over the preferred `Document.Delete()` method. Furthermore, it continues to bloat the growing `WaivesClient` class.
* **Add a static `Delete()` method to `Document`.** This is tricky to implement because `Document` needs a reference to the `IHttpRequestSender` object graph. 

### Further work

None.