### PR TITLE
Allow Newtonsoft to set ApiError.Message

### DIFF
--- a/src/Waives.Http/Responses/ApiError.cs
+++ b/src/Waives.Http/Responses/ApiError.cs
@@ -1,7 +1,10 @@
-﻿namespace Waives.Http.Responses
+﻿using Newtonsoft.Json;
+
+namespace Waives.Http.Responses
 {
     internal class ApiError
     {
+        [JsonProperty]
         internal string Message { get; set; }
     }
 }

--- a/test/Waives.Http.Tests/RequestHandling/FailedRequestHandlingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/FailedRequestHandlingRequestSenderFacts.cs
@@ -29,7 +29,8 @@ namespace Waives.Http.Tests
                 .Send(_request)
                 .ReturnsForAnyArgs(Response.ErrorFrom(statusCode, _request));
 
-            await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Send(_request));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Send(_request));
+            Assert.Equal(Response.ErrorMessage, exception.Message);
         }
 
         [Theory, MemberData(nameof(SuccessStatusCodes))]


### PR DESCRIPTION
Fixes #41.

### Root cause

#41 was regressed with c590cfc7 when the `ApiError` class was made internal: Newtonsoft.Json could no longer resolve the `Message` property to set it. 

### Proposed resolution

By decorating this property with a `[JsonProperty]` attribute, it is made visible to Newtonsoft.Json again and the error messages are restored. 
