### PR TITLE
Improve thrown PipelineExceptions

### DIFF
--- a/src/Waives.Pipelines/PipelineException.cs
+++ b/src/Waives.Pipelines/PipelineException.cs
@@ -11,13 +11,6 @@ namespace Waives.Pipelines
         {
         }
 
-        public PipelineException(Exception innerException)
-            : base("A fatal error occurred in the processing pipeline. View the InnerException " +
-                   "for more details.", innerException)
-        {
-
-        }
-
         public PipelineException(string message) : base(message)
         {
         }

--- a/src/Waives.Pipelines/PipelineObserver.cs
+++ b/src/Waives.Pipelines/PipelineObserver.cs
@@ -18,7 +18,7 @@ namespace Waives.Pipelines
 
         public void OnError(Exception error)
         {
-            throw new PipelineException(error);
+            throw new PipelineException($"A fatal error occurred in the processing pipeline: {error.Message}", error);
         }
 
         public void OnNext(WaivesDocument value)


### PR DESCRIPTION
This was in response to a comment in a video call that we weren't properly handling (and were even swallowing) exceptions which were being thrown by the document error handler provided to a Pipeline. This turns out not to be the case, but I've added a test verifying that this is the case to guard against regressions. I've also improved the `PipelineException`'s message by including its `InnerException`'s message.