### PR TITLE
Add Read method to Document

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -46,7 +46,7 @@ namespace Waives.Http
         /// will use the results from this operation.
         /// </summary>
         /// <remarks>Not all types of files support this operation.
-        /// See the document for a list of supported file types. If you are doing
+        /// See the documentation for a list of supported file types. If you are doing
         /// multiple classifications or extractions with different configurations
         /// it is most efficient to call this method first, so the document is only
         /// read once.</remarks>

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -42,6 +42,25 @@ namespace Waives.Http
         }
 
         /// <summary>
+        /// Reads text from the document. Subsequent calls to Classify and Extract
+        /// will use the results from this operation.
+        /// </summary>
+        /// <remarks>Not all types of files support this operation.
+        /// See the document for a list of supported file types. If you are doing
+        /// multiple classifications or extractions with different configurations
+        /// it is most efficient to call this method first, so the document is only
+        /// read once.</remarks>
+        public async Task Read()
+        {
+            var readUrl = _behaviours["document:read"];
+
+            var request = new HttpRequestMessageTemplate(HttpMethod.Put,
+                readUrl.CreateUri());
+
+            await _requestSender.Send(request).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Performs classification on this document using the given classifer
         /// name. The named classifier must already exist in the Waives platform.
         /// </summary>


### PR DESCRIPTION
This PR adds a `Read` method to the `Document` class. This means we can explicitly trigger a read when we know we'll be doing multiple classifications/extractions in parallel and only want to do one read. Otherwise each would kick off a read automatically.

------------------------------
Connects #58 