### PR TITLE
Add GetReadResults method to Document class

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -74,8 +74,6 @@ namespace Waives.Http
             using (var fileStream = File.OpenWrite(path))
             {
                 await GetReadResults(fileStream, format).ConfigureAwait(false);
-
-                fileStream.Close();
             }
         }
 

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -95,7 +95,7 @@ namespace Waives.Http
                 readUrl.CreateUri(),
                 new List<KeyValuePair<string, string>>
                 {
-                    new KeyValuePair<string, string>("Accept", ResultsFormatToMimeType(format))
+                    new KeyValuePair<string, string>("Accept", format.ToMimeType())
                 });
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);
@@ -148,19 +148,6 @@ namespace Waives.Http
             var response = await _requestSender.Send(request).ConfigureAwait(false);
             var responseBody = await response.Content.ReadAsAsync<ExtractionResults>().ConfigureAwait(false);
             return responseBody;
-        }
-
-        private static string ResultsFormatToMimeType(ReadResultsFormat format)
-        {
-            switch (format)
-            {
-                case ReadResultsFormat.Text:
-                    return "text/plain";
-                case ReadResultsFormat.Pdf:
-                    return "application/pdf";
-                default:
-                    return "application/vnd.waives.resultformats.read+zip";
-            }
         }
     }
 }

--- a/src/Waives.Http/ReadResultsFormat.cs
+++ b/src/Waives.Http/ReadResultsFormat.cs
@@ -1,0 +1,9 @@
+﻿namespace Waives.Http
+{
+    public enum ReadResultsFormat
+    {
+        Text = 0,
+        Pdf = 1,
+        WaivesDocument = 2
+    }
+}

--- a/src/Waives.Http/ReadResultsFormatExtensions.cs
+++ b/src/Waives.Http/ReadResultsFormatExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace Waives.Http
+{
+    public static class ReadResultsFormatExtensions
+    {
+        public static string ToMimeType(this ReadResultsFormat format)
+        {
+            switch (format)
+            {
+                case ReadResultsFormat.Text:
+                    return "text/plain";
+                case ReadResultsFormat.Pdf:
+                    return "application/pdf";
+                default:
+                    return "application/vnd.waives.resultformats.read+zip";
+            }
+        }
+    }
+}

--- a/src/Waives.Http/RequestHandling/HttpRequestMessageTemplate.cs
+++ b/src/Waives.Http/RequestHandling/HttpRequestMessageTemplate.cs
@@ -6,6 +6,11 @@ namespace Waives.Http.RequestHandling
 {
     internal class HttpRequestMessageTemplate
     {
+        public HttpRequestMessageTemplate(HttpMethod method, Uri requestUri, List<KeyValuePair<string, string>> headers) : this(method, requestUri)
+        {
+            Headers = headers;
+        }
+
         public HttpRequestMessageTemplate(HttpMethod method, Uri requestUri)
         {
             Method = method ?? throw new ArgumentNullException(nameof(method));


### PR DESCRIPTION
This PR adds a `GetReadResults()` method to the Document class, with two overloads:
 - `Task GetReadResults(string path, ReadResultsFormat format)`
 - `Task GetReadResults(Stream resultsStream, ReadResultsFormat format)`

The change is covered by unit tests and I have tested both methods and all results formats manually.