### PR TITLE
Add Create Document (import) support to Waives.Http

### DIFF
--- a/src/Waives.Http/JsonContent.cs
+++ b/src/Waives.Http/JsonContent.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Waives.Http
+{
+    internal class JsonContent : StringContent
+    {
+        public JsonContent(object obj) :
+            base(JsonConvert.SerializeObject(obj), Encoding.UTF8, (string)"application/json")
+        { }
+    }
+}

--- a/src/Waives.Http/Requests/ImportDocumentRequest.cs
+++ b/src/Waives.Http/Requests/ImportDocumentRequest.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Waives.Http.Requests
+{
+    public class ImportDocumentRequest
+    {
+        [JsonProperty("url")]
+#pragma warning disable CA1056 // Uri properties should not be strings
+        public string Url { get; set; }
+#pragma warning restore CA1056 // Uri properties should not be strings
+    }
+}

--- a/src/Waives.Http/Waives.Http.csproj
+++ b/src/Waives.Http/Waives.Http.csproj
@@ -15,11 +15,18 @@
     <Product>Waives.io</Product>
     <Description>This is the HTTP client library for calling the Waives API from .NET.</Description>
     <Copyright>CloudHub 360 Ltd.</Copyright>
-    <PackageLicenseUrl>https://github.com/waives/waives.net/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageId>Waives.Http</PackageId>
     <AssemblyName>Waives.Http</AssemblyName>
     <RootNamespace>Waives.Http</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="..\..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
+++ b/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
@@ -8,7 +8,6 @@
     <Product>Waives.io</Product>
     <Description>This extension provides file system-appropriate implementations of DocumentChannel from the core library.</Description>
     <Copyright>CloudHub 360 Ltd.</Copyright>
-    <PackageLicenseUrl>https://github.com/waives/waives.net/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/41697261?s=400&amp;amp;u=232bcf1c9ce942b67c9d42925ba8242602dccbe5&amp;amp;v=4</PackageIconUrl>
     <RepositoryUrl>https://github.com/waives/waives.net</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -16,6 +15,14 @@
     <AssemblyName>Waives.Pipelines.Extensions.DocumentSources.FileSystem</AssemblyName>
     <RootNamespace>Waives.Pipelines.Extensions.DocumentSources.FileSystem</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="..\..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Waives.Pipelines/Waives.Pipelines.csproj
+++ b/src/Waives.Pipelines/Waives.Pipelines.csproj
@@ -12,7 +12,6 @@
     <Product>Waives.io</Product>
     <Authors>CloudHub 360 Ltd.</Authors>
     <Copyright>CloudHub 360 Ltd.</Copyright>
-    <PackageLicenseUrl>https://github.com/waives/waives.net/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/41697261?s=400&amp;u=232bcf1c9ce942b67c9d42925ba8242602dccbe5&amp;v=4</PackageIconUrl>
     <RepositoryUrl>https://github.com/waives/waives.net</RepositoryUrl>
@@ -21,6 +20,14 @@
     <Description>This provides a Pipeline-based API for building document processing pipelines with the Waives API.</Description>
     <PackageId>Waives.Pipelines</PackageId>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="..\..\LICENSE.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Waives.Http.Tests/Waives.Http.Tests.csproj
+++ b/test/Waives.Http.Tests/Waives.Http.Tests.csproj
@@ -33,4 +33,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Requests\" />
+  </ItemGroup>
+
 </Project>

--- a/test/Waives.Http.Tests/Waives.Http.Tests.csproj
+++ b/test/Waives.Http.Tests/Waives.Http.Tests.csproj
@@ -33,8 +33,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Requests\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This PR adds a `CreateDocument(Uri uri)` method to the Waives.Http client to enable creation of a document from a file residing on a different system. 

This method posts a request to `/documents` with the url specified in the body.

The PR also includes a fix for broken builds due to a nuget license property being deprecated.

--------------
Connects CloudHub360/platform#1429