### PR TITLE
Fix Waives.NET SDK auto-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-ARG tag=2.1-sdk
-FROM microsoft/dotnet:${tag}
+ARG tag=2.1.700
+FROM mcr.microsoft.com/dotnet/core/sdk:${tag}-bionic
 
-RUN apt-get update && \
-    apt-get install -y curl gnupg apt-transport-https && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' && \
+RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
     apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository universe && \
     apt-get install -y powershell
+


### PR DESCRIPTION
The fix is to update the build Docker image to use the new 2.1.700 release of the .NET Core SDK. This ensures the `PackageLicenseFile` directive in the csproj files is respected. Per the [documentation ](https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#packagelicensefile), this directive is supported in 2.1.502 and later, but the SDK previously used was an earlier 2.1.xxx version. 

PowerShell Core has [new installation instructions](https://docs.microsoft.com/en-gb/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-6#installation-via-package-repository---ubuntu-1804), so the Dockerfile is updated appropriately for these too.

The Docker image has been built locally and pushed to Docker Hub, and verified to be working on TeamCity.