### PR TITLE
Provide a helpful error if document stream is empty

### DIFF
--- a/src/Waives.Http/Waives.Http.csproj
+++ b/src/Waives.Http/Waives.Http.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -131,7 +131,6 @@ namespace Waives.Http
                 throw new ArgumentNullException(nameof(documentSource));
             }
 
-            var bytesRead = int.MaxValue;
             if (!documentSource.CanSeek)
             {
                 // This Stream implementation from ASP.NET Core buffers streams larger than the specified threshold to
@@ -143,11 +142,11 @@ namespace Waives.Http
                     30 * 1000 * 1000, /* 30 MB */
                     Path.GetTempPath);
 
-                bytesRead = await documentSource.ReadAsync(new byte[1], 0, 1).ConfigureAwait(false);
+                await documentSource.ReadAsync(new byte[1], 0, 1).ConfigureAwait(false);
                 documentSource.Seek(0, SeekOrigin.Begin);
             }
 
-            if (documentSource.Length < 1 || bytesRead < 1)
+            if (documentSource.Length < 1)
             {
                 throw new ArgumentException("The provided stream has no content.", nameof(documentSource));
             }

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -130,7 +130,7 @@ namespace Waives.Http
                 throw new ArgumentNullException(nameof(documentSource));
             }
 
-            if (documentSource.Length < 1)
+            if (documentSource.CanSeek && documentSource.Length < 1)
             {
                 throw new ArgumentException("The provided stream has no content.", nameof(documentSource));
             }

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -125,6 +125,16 @@ namespace Waives.Http
         /// <seealso cref="Document.Delete"/>
         public async Task<Document> CreateDocument(Stream documentSource)
         {
+            if (documentSource == null)
+            {
+                throw new ArgumentNullException(nameof(documentSource));
+            }
+
+            if (documentSource.Length < 1)
+            {
+                throw new ArgumentException("The provided stream has no content.", nameof(documentSource));
+            }
+
             var request =
                 new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
                 {

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -135,6 +135,15 @@ namespace Waives.Http
                 throw new ArgumentException("The provided stream has no content.", nameof(documentSource));
             }
 
+            if (!documentSource.CanSeek)
+            {
+                var bytesRead = documentSource.Read(new byte[1], 0, 1);
+                if (bytesRead < 1)
+                {
+                    throw new ArgumentException("The provided stream has no content.", nameof(documentSource));
+                }
+            }
+
             var request =
                 new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents", UriKind.Relative))
                 {

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -64,6 +64,24 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
+        public async Task CreateDocument_sends_the_supplied_unseekable_stream_as_content()
+        {
+            _requestSender
+                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
+
+            using (var stream = new UnseekableMemoryStream(_documentContents))
+            {
+                await _sut.CreateDocument(stream);
+
+                await _requestSender
+                    .Received(1)
+                    .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                        RequestContentEquals(m, _documentContents)));
+            }
+        }
+
+        [Fact]
         public async Task CreateDocument_sends_the_supplied_file_as_content()
         {
             const string filePath = "DummyDocument.txt";

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -154,6 +154,21 @@ namespace Waives.Http.Tests
         }
 
         [Fact]
+        public async Task CreateDocument_throws_if_stream_is_empty()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateDocument(Stream.Null));
+            Assert.Contains("The provided stream has no content.", exception.Message);
+            Assert.Equal("documentSource", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task CreateDocument_throws_if_stream_is_null()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.CreateDocument((Stream)null));
+            Assert.Equal("documentSource", exception.ParamName);
+        }
+
+        [Fact]
         public async Task GetDocument_sends_a_request_to_the_correct_url()
         {
             _requestSender


### PR DESCRIPTION
Previously, we sent the empty stream merrily on it's way to the Waives API, where it was read and returned with a message stating "the body of this request should be a binary file", which doesn't provide the clearest indication of where the problem lies.

We now guard against null and empty document streams, and provide a more appropriate message in these situations using `ArgumentException`s.

Fixes #53.