### PR TITLE
Remove reference to ASP.NET WebApiClient

### DIFF
--- a/src/Waives.Http/JsonContent.cs
+++ b/src/Waives.Http/JsonContent.cs
@@ -1,5 +1,7 @@
-﻿using System.Net.Http;
+﻿using System.IO;
+using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Waives.Http
@@ -9,5 +11,20 @@ namespace Waives.Http
         public JsonContent(object obj) :
             base(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json")
         { }
+    }
+
+    internal static class JsonContentExtensions
+    {
+        public static async Task<T> ReadAsAsync<T>(this HttpContent httpContent)
+        {
+            var responseStream = await httpContent.ReadAsStreamAsync().ConfigureAwait(false);
+
+            using (var reader = new StreamReader(responseStream))
+            using (var jsonTextReader = new JsonTextReader(reader))
+            {
+                var response = new JsonSerializer().Deserialize<T>(jsonTextReader);
+                return response;
+            }
+        }
     }
 }

--- a/src/Waives.Http/Waives.Http.csproj
+++ b/src/Waives.Http/Waives.Http.csproj
@@ -9,7 +9,7 @@
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/41697261?s=400&amp;u=232bcf1c9ce942b67c9d42925ba8242602dccbe5&amp;v=4</PackageIconUrl>
     <RepositoryUrl>https://github.com/waives/waives.net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.2.0</Version>
+    <Version>1.0.0</Version>
     <Authors>CloudHub 360 Ltd.</Authors>
     <Company>CloudHub 360 Ltd.</Company>
     <Product>Waives.io</Product>
@@ -39,12 +39,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
+using Newtonsoft.Json;
 using Waives.Http.Logging;
 using Waives.Http.RequestHandling;
 using Waives.Http.Requests;
@@ -158,9 +159,9 @@ namespace Waives.Http
                 };
 
             var response = await _requestSender.Send(request).ConfigureAwait(false);
-            var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
+            var document = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
 
-            return new Document(_requestSender, responseContent.Id, responseContent.Links);
+            return new Document(_requestSender, document.Id, document.Links);
         }
 
         /// <summary>

--- a/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
+++ b/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.0</Version>
+    <Version>1.0.0</Version>
     <Company>CloudHub 360 Ltd.</Company>
     <Authors>CloudHub 360 Ltd.</Authors>
     <Product>Waives.io</Product>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <None Include="..\..\LICENSE.md" Pack="true" PackagePath=""/>
+      <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Waives.Pipelines/Waives.Pipelines.csproj
+++ b/src/Waives.Pipelines/Waives.Pipelines.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Waives.Pipelines</AssemblyName>
     <RootNamespace>Waives.Pipelines</RootNamespace>
-    <Version>0.3.0</Version>
+    <Version>1.0.0</Version>
     <Company>CloudHub 360 Ltd.</Company>
     <Product>Waives.io</Product>
     <Authors>CloudHub 360 Ltd.</Authors>

--- a/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Waives.Http.Logging;
@@ -60,12 +61,15 @@ namespace Waives.Http.Tests.RequestHandling
                 return false;
             }
 
-            var formData = content.ReadAsFormDataAsync().Result;
+            var contentStream = content.ReadAsStreamAsync().Result;
+            using (var reader = new FormReader(contentStream))
+            {
+                var formData = reader.ReadFormAsync().Result;
 
-            Assert.Equal(expectedClientId, formData["client_id"]);
-            Assert.Equal(expectedClientSecret, formData["client_secret"]);
-
-            return true;
+                Assert.Equal(expectedClientId, formData["client_id"]);
+                Assert.Equal(expectedClientSecret, formData["client_secret"]);
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
This is an unmaintained package now, and we were referencing only a single method from it in the library (ReadAsAync<T>()). It depends on an older version of Newtonsoft.Json which, in a .NET Framework project, resolves to v6 or so. An implementation of ReadAsAsync<T>() is now included in Waives.Http, and the latest version of Newtonsoft.Json is referenced directly from the library.

Fixes #38.