### PR TITLE
Add redaction support to Waives.Http

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -141,6 +141,21 @@ namespace Waives.Http
             return await extractionResponse.ReadAsAsync<ExtractionResults>().ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Performs redaction on this document using results from an
+        /// <see cref="Extract" langword="extraction"/> operation using the
+        /// specified extractor name. The named extractor must already exist in
+        /// the Waives platform. The result of this operation is a PDF file with
+        /// the extracted data removed from the file.
+        /// </summary>
+        /// <param name="extractorName">
+        /// The name of the extractor to use to identify the areas of the
+        /// document to redact.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Stream"/> of bytes containing a PDF file. The returned
+        /// Stream should be disposed of in your own code.
+        /// </returns>
         public async Task<Stream> Redact(string extractorName)
         {
             var extractionResponse =

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -147,5 +147,17 @@ namespace Waives.Http
             var responseBody = await response.Content.ReadAsAsync<ExtractionResults>().ConfigureAwait(false);
             return responseBody;
         }
+
+        public async Task<Stream> Redact(string extractorName)
+        {
+            var redactions = await Extract(extractorName).ConfigureAwait(false);
+            var request = new HttpRequestMessageTemplate(HttpMethod.Post, new Uri($"/documents/{Id}/redact", UriKind.Relative))
+            {
+                Content = new JsonContent(redactions)
+            };
+
+            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/src/Waives.Http/JsonContent.cs
+++ b/src/Waives.Http/JsonContent.cs
@@ -11,6 +11,10 @@ namespace Waives.Http
         public JsonContent(object obj) :
             base(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json")
         { }
+
+        public JsonContent(string json) :
+            base(json, Encoding.UTF8, "application/json")
+        { }
     }
 
     internal static class JsonContentExtensions

--- a/src/Waives.Http/Requests/RedactionRequest.cs
+++ b/src/Waives.Http/Requests/RedactionRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Waives.Http.Requests
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    internal class RedactionRequest
+    {
+        internal const string MimeType = "application/vnd.waives.requestformats.redact+json";
+    }
+}

--- a/src/Waives.Http/Responses/ExtractionResults.cs
+++ b/src/Waives.Http/Responses/ExtractionResults.cs
@@ -9,6 +9,8 @@ namespace Waives.Http.Responses
     /// </summary>
     public class ExtractionResults
     {
+        internal const string MimeType = "application/vnd.waives.resultformats.extractdata+json";
+
         /// <summary>
         /// Gets the extraction results for the document.
         /// </summary>

--- a/test/Waives.Http.Tests/RequestHandling/Response.cs
+++ b/test/Waives.Http.Tests/RequestHandling/Response.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Waives.Http.RequestHandling;
@@ -103,6 +104,14 @@ namespace Waives.Http.Tests.RequestHandling
             return From(HttpStatusCode.OK, requestTemplate, new StringContent(ExtractResponse)
             {
                 Headers = {ContentType = new MediaTypeHeaderValue("application/json")}
+            });
+        }
+
+        public static HttpResponseMessage Redact(HttpRequestMessageTemplate requestTemplate)
+        {
+            return From(HttpStatusCode.OK, requestTemplate, new StreamContent(new MemoryStream(RedactResponse))
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("application/pdf") }
             });
         }
 
@@ -306,5 +315,7 @@ namespace Waives.Http.Tests.RequestHandling
         }]
     }
 }";
+
+        private static readonly byte[] RedactResponse = { 1, 2, 3};
     }
 }


### PR DESCRIPTION
This adds a new method to the Waives.Http library, `Document.Redact()`, which takes an extractor name and returns a `Stream` containing a PDF with the extraction results redacted. See [Using redactoin without manual review](https://docs.waives.io/docs/redaction-overview#section-using-redaction-without-manual-review) for more details.

Based on the [API reference documentation](https://docs.waives.io/v2.1/reference#section-creating-a-redaction-request-based-on-extraction-results), I believe that bookmarks are automatically added to the PDF when using extraction results as the request body, and that this completes the work for the Waives.Http library for this feature.