### PR TITLE
Build symbols packages for SDK libraries

### DIFF
--- a/src/Waives.Http/Waives.Http.csproj
+++ b/src/Waives.Http/Waives.Http.csproj
@@ -10,6 +10,8 @@
     <RepositoryUrl>https://github.com/waives/waives.net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Version>1.0.0</Version>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>CloudHub 360 Ltd.</Authors>
     <Company>CloudHub 360 Ltd.</Company>
     <Product>Waives.io</Product>

--- a/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
+++ b/src/Waives.Pipelines.Extensions.DocumentSources.FileSystem/Waives.Pipelines.Extensions.DocumentSources.FileSystem.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.0.0</Version>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>CloudHub 360 Ltd.</Company>
     <Authors>CloudHub 360 Ltd.</Authors>
     <Product>Waives.io</Product>

--- a/src/Waives.Pipelines/Waives.Pipelines.csproj
+++ b/src/Waives.Pipelines/Waives.Pipelines.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>Waives.Pipelines</AssemblyName>
     <RootNamespace>Waives.Pipelines</RootNamespace>
     <Version>1.0.0</Version>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>CloudHub 360 Ltd.</Company>
     <Product>Waives.io</Product>
     <Authors>CloudHub 360 Ltd.</Authors>


### PR DESCRIPTION
These symbols packages are useful for debugging the library in an application, which depends on the SDK NuGet packages. 