### PR TITLE
Add support for redaction operations to Pipelines API

### DIFF
--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Waives.Http.Responses;
@@ -14,6 +14,8 @@ namespace Waives.Pipelines.HttpAdapters
         Task<ClassificationResult> Classify(string classifierName);
 
         Task<ExtractionResults> Extract(string extractorName);
+
+        Task<Stream> Redact(string extractorName);
 
         Task Delete();
 
@@ -45,6 +47,11 @@ namespace Waives.Pipelines.HttpAdapters
         public async Task<ExtractionResults> Extract(string extractorName)
         {
             return await _documentClient.Extract(extractorName).ConfigureAwait(false);
+        }
+
+        public async Task<Stream> Redact(string extractorName)
+        {
+            return await _documentClient.Redact(extractorName).ConfigureAwait(false);
         }
 
         public async Task Delete()

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -29,8 +29,11 @@ namespace Waives.Pipelines
     ///
     ///         public static async Task MainAsync(string[] args)
     ///         {
-    ///             await WaivesApi.Login("clientId", "clientSecret");
-    ///             var pipeline = WaivesApi.CreatePipeline();
+    ///             var pipeline = WaivesApi.CreatePipeline(new WaivesOptions
+    ///             {
+    ///                 ClientId = "clientId",
+    ///                 ClientSecret = "clientSecret"
+    ///             });
     ///
     ///             pipeline
     ///                 .WithDocumentsFrom(FileSystemSource.Create(@"C:\temp\inbox"))
@@ -40,7 +43,7 @@ namespace Waives.Pipelines
     ///
     ///             try
     ///             {
-    ///                 pipeline.Start();
+    ///                 await pipeline.RunAsync();
     ///             }
     ///             catch (WaivesException ex)
     ///             {

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -142,7 +142,7 @@ namespace Waives.Pipelines
         /// <param name="extractorName"></param>
         /// <param name="resultFunc"></param>
         /// <returns></returns>
-        public Pipeline RedactWith(string extractorName, Func<Stream, Task> resultFunc)
+        public Pipeline RedactWith(string extractorName, Func<WaivesDocument, Stream, Task> resultFunc)
         {
             _docActions.Add(async d =>
             {

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -140,8 +140,60 @@ namespace Waives.Pipelines
         }
 
         /// <summary>
-        ///
+        /// Redacts data from documents, based on extraction results provided by the specified extractor. The extractor
+        /// must have been created previously in your Waives account in order to be used here.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The result of a redaction operation is the original document, converted to a PDF file if required, and with
+        /// the extraction results removed from the electronic content of the file. Additionally, the content is removed
+        /// from the document image, replaced with a black bar. This PDF document is returned as a <see cref="Stream"/>
+        /// from the Waives API, and so a callback must be supplied accepting this <see cref="Stream"/>.
+        /// </para>
+        /// <para>
+        /// The redaction functionality is currently a beta-stage feature of the Waives API and has a couple of known
+        /// issues.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <![CDATA[
+        /// using System;
+        /// using System.Threading.Tasks;
+        /// using Waives.Pipelines;
+        /// using Waives.Pipelines.Extensions.DocumentSources.FileSystem
+        ///
+        /// namespace Waives.Pipelines.Example
+        /// {
+        ///     public class Program
+        ///     {
+        ///         public static void Main(string[] args)
+        ///         {
+        ///             Task.Run(() => MainAsync(args)).Wait();
+        ///         }
+        ///
+        ///         public static async Task MainAsync(string[] args)
+        ///         {
+        ///             var pipeline = WaivesApi.CreatePipeline(new WaivesOptions
+        ///             {
+        ///                 ClientId = "clientId",
+        ///                 ClientSecret = "clientSecret"
+        ///             });
+        ///
+        ///             pipeline
+        ///                 .WithDocumentsFrom(FileSystemSource.Create(@"C:\temp\inbox"))
+        ///                 .RedactWith("my-extractor", async (d, redactedPdf) =>
+        ///                 {
+        ///                     var redactedFilePath = $"{d.Source.SourceId}.redacted.pdf";
+        ///                     using (var fileStream = File.OpenWrite(redactedFilePath))
+        ///                     {
+        ///                         await redactedPdf.CopyTo(fileStream);
+        ///                     }
+        ///                 });
+        ///         }
+        ///     }
+        /// }
+        /// ]]>
+        /// </example>
         /// <param name="extractorName"></param>
         /// <param name="resultFunc"></param>
         /// <returns></returns>

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Waives.Http.Logging;
@@ -129,6 +130,28 @@ namespace Waives.Pipelines
                     "Extracted data from document {DocumentId} from '{DocumentSource}'",
                     d.Id,
                     d.Source.SourceId);
+                return document;
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="extractorName"></param>
+        /// <param name="resultFunc"></param>
+        /// <returns></returns>
+        public Pipeline RedactWith(string extractorName, Func<Stream, Task> resultFunc)
+        {
+            _docActions.Add(async d =>
+            {
+                var document = await d.Redact(extractorName, resultFunc).ConfigureAwait(false);
+                _logger.Info(
+                    "Redacted data from document {DocumentId} from '{DocumentSource}' using extractor '{ExtractorName}'",
+                    d.Id,
+                    d.Source.SourceId,
+                    extractorName);
                 return document;
             });
 

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Waives.Http.Responses;
 using Waives.Pipelines.HttpAdapters;
@@ -44,6 +45,14 @@ namespace Waives.Pipelines
                 ClassificationResults = ClassificationResults,
                 ExtractionResults = await _waivesDocument.Extract(extractorName).ConfigureAwait(false)
             };
+        }
+
+        public async Task<WaivesDocument> Redact(string extractorName, Func<Stream, Task> resultFunc)
+        {
+            var resultStream = await _waivesDocument.Redact(extractorName);
+            await resultFunc(resultStream);
+
+            return this;
         }
 
         public async Task Delete()

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -49,6 +49,16 @@ namespace Waives.Pipelines
 
         public async Task<WaivesDocument> Redact(string extractorName, Func<WaivesDocument, Stream, Task> resultFunc)
         {
+            if (string.IsNullOrWhiteSpace(extractorName))
+            {
+                throw new ArgumentNullException(nameof(extractorName));
+            }
+
+            if (resultFunc == null)
+            {
+                throw new ArgumentNullException(nameof(resultFunc));
+            }
+
             var resultStream = await _waivesDocument.Redact(extractorName);
             await resultFunc(this, resultStream);
 

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -47,10 +47,10 @@ namespace Waives.Pipelines
             };
         }
 
-        public async Task<WaivesDocument> Redact(string extractorName, Func<Stream, Task> resultFunc)
+        public async Task<WaivesDocument> Redact(string extractorName, Func<WaivesDocument, Stream, Task> resultFunc)
         {
             var resultStream = await _waivesDocument.Redact(extractorName);
-            await resultFunc(resultStream);
+            await resultFunc(this, resultStream);
 
             return this;
         }

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -97,8 +97,9 @@ namespace Waives.Pipelines.Tests
 
             var pipeline = _sut
                 .WithDocumentsFrom(source)
-                .RedactWith(extractorName, redactedPdf =>
+                .RedactWith(extractorName, (d, redactedPdf) =>
                 {
+                    Assert.Equal(TestDocument.SourceIdString, d.Source.SourceId);
                     AssertStreamsAreEqual(new MemoryStream(new byte[] { 1, 2, 3 }), redactedPdf);
                     return Task.CompletedTask;
                 });

--- a/test/Waives.Pipelines.Tests/TestDocument.cs
+++ b/test/Waives.Pipelines.Tests/TestDocument.cs
@@ -5,7 +5,9 @@ namespace Waives.Pipelines.Tests
 {
     internal class TestDocument : Document
     {
-        public TestDocument(byte[] contents, string sourceId = "Test Document") : base(sourceId)
+        internal const string SourceIdString = "Test Document";
+
+        public TestDocument(byte[] contents, string sourceId = SourceIdString) : base(sourceId)
         {
             Stream = new MemoryStream(contents);
         }


### PR DESCRIPTION
This PR completes the work necessary to fully support redaction operations throughout Waives.NET. It introduces a new `RedactWith()` operation to the Pipeline, which accepts an extractor name and a callback for handling the redaction results. 

As with the HTTP library (#82), we redact based on results provided by the specified extractor, and receive a Stream containing the redacted PDF. In the Pipeline API, we need to keep the fluency of the pipeline configuration, so `Pipeline.RedactWith()` additionally accepts an async callback function to allow the calling application to perform some operation with the resulting Stream (e.g. writing it to disk). A `WaivesDocument` parameter on the callback function allows the Stream to be associated with the source document, e.g. if wishing to use a result filename based on the source's. 

The PR also updates documentation in the Pipeline class to reflect the changes made in #81.

Closes #68.