### PR TITLE
Fix #55, "unhandled exceptions stall pipeline"

### DIFF
--- a/src/Waives.Pipelines/DocumentProcessor.cs
+++ b/src/Waives.Pipelines/DocumentProcessor.cs
@@ -9,27 +9,38 @@ namespace Waives.Pipelines
     {
         private readonly Func<Document, Task<WaivesDocument>> _docCreator;
         private readonly IEnumerable<Func<WaivesDocument, Task<WaivesDocument>>> _docActions;
+        private readonly Func<WaivesDocument, Task> _docDeleter;
         private readonly Action<Exception, Document> _onDocumentException;
 
         public DocumentProcessor(Func<Document, Task<WaivesDocument>> docCreator,
             IEnumerable<Func<WaivesDocument, Task<WaivesDocument>>> docActions,
+            Func<WaivesDocument, Task> docDeleter,
             Action<Exception, Document> onDocumentException)
         {
             _docCreator = docCreator ?? throw new ArgumentNullException(nameof(docCreator));
             _docActions = docActions ?? throw new ArgumentNullException(nameof(docActions));
+            _docDeleter = docDeleter ?? throw new ArgumentNullException(nameof(docDeleter));
             _onDocumentException = onDocumentException ?? throw new ArgumentNullException(nameof(onDocumentException));
         }
 
         public async Task RunAsync(Document document)
         {
+            WaivesDocument waivesDocument = null;
             try
             {
-                var waivesDocument = await _docCreator(document);
+                waivesDocument = await _docCreator(document);
                 await RunActions(waivesDocument).ConfigureAwait(false);
             }
             catch (Exception e)
             {
                 _onDocumentException(e, document);
+            }
+            finally
+            {
+                if (waivesDocument != null)
+                {
+                    await _docDeleter(waivesDocument);
+                }
             }
         }
 

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -226,6 +226,21 @@ namespace Waives.Pipelines.Tests
         }
 
         [Fact]
+        public async Task RunAsync_throws_when_OnDocumentError_throws()
+        {
+            var document = new TestDocument(Generate.Bytes());
+            var source = Observable.Repeat(document, 1);
+
+            await Assert.ThrowsAsync<Exception>(() => _sut.WithDocumentsFrom(source)
+                .Then(waivesDocument => throw new Exception())
+                .OnDocumentError(err =>
+                {
+                    throw new Exception();
+                })
+                .RunAsync());
+        }
+
+        [Fact]
         public async Task OnDocumentError_is_run_multiple_times_in_correct_order_if_specified()
         {
             var onDocumentErrorCalledFor = new List<(DocumentError error, int sequence)>();


### PR DESCRIPTION
This PR:

* Ensures that user-supplied error handlers no longer stall the pipeline
* If any error handlers do throw, any document created in waives is also deleted
* Ensures that `Pipeline.RunAsync` also throws, since there's nothing else we can do.

Fixes #55.