### PR TITLE
Rename async methods

### DIFF
--- a/samples/BlobStorageProcessor/Program.cs
+++ b/samples/BlobStorageProcessor/Program.cs
@@ -62,7 +62,7 @@ namespace BlobStorageProcessor
             var blobStorage = new EnumerableDocumentSource(blobStorageDocuments);
 
             var writer = CreateResultWriter(options["--output"].ToString());
-            var pipeline = await WaivesApi.CreatePipeline(new WaivesOptions
+            var pipeline = await WaivesApi.CreatePipelineAsync(new WaivesOptions
             {
                 ClientId = "clientId",
                 ClientSecret = "clientSecret"

--- a/samples/FileSorter/Program.cs
+++ b/samples/FileSorter/Program.cs
@@ -61,7 +61,7 @@ namespace FileSorter
             // inbox path.
             var filesystem = FileSystem.WatchForChanges(inbox, cancellation.Token);
 
-            var pipeline = await WaivesApi.CreatePipeline(new WaivesOptions
+            var pipeline = await WaivesApi.CreatePipelineAsync(new WaivesOptions
             {
                 ClientId = "clientId",
                 ClientSecret = "clientSecret"

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -40,7 +40,7 @@ namespace Waives.Http
             var request = new HttpRequestMessageTemplate(HttpMethod.Delete,
                 selfUrl.CreateUri());
 
-            await _requestSender.Send(request).ConfigureAwait(false);
+            await _requestSender.SendAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Waives.Http
             var request = new HttpRequestMessageTemplate(HttpMethod.Put,
                 readUrl.CreateUri());
 
-            await _requestSender.Send(request).ConfigureAwait(false);
+            await _requestSender.SendAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Waives.Http
                     { "Accept", format.ToMimeType() }
                 });
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
             var responseBody = await response
                 .Content
                 .ReadAsStreamAsync()
@@ -124,7 +124,7 @@ namespace Waives.Http
                     classifier_name = classifierName
                 }));
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
             var responseBody = await response.Content.ReadAsAsync<ClassificationResponse>().ConfigureAwait(false);
             return responseBody.ClassificationResults;
         }
@@ -168,7 +168,7 @@ namespace Waives.Http
                 Content = new JsonContent(redactions)
             };
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
             return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
@@ -188,7 +188,7 @@ namespace Waives.Http
                     { "Accept", desiredResponseFormat }
                 });
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
             return response.Content;
         }
     }

--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -33,7 +33,7 @@ namespace Waives.Http
         /// <summary>
         /// Deletes this document in the Waives platform.
         /// </summary>
-        public async Task Delete()
+        public async Task DeleteAsync()
         {
             var selfUrl = _behaviours["self"];
 
@@ -52,7 +52,7 @@ namespace Waives.Http
         /// multiple classifications or extractions with different configurations
         /// it is most efficient to call this method first, so the document is only
         /// read once.</remarks>
-        public async Task Read()
+        public async Task ReadAsync()
         {
             var readUrl = _behaviours["document:read"];
 
@@ -70,11 +70,11 @@ namespace Waives.Http
         /// <param name="format">The format of the results required</param>
         /// <remarks>The Read method must be called before this method, otherwise a
         /// WaivesApiException will be thrown.</remarks>
-        public async Task GetReadResults(string path, ReadResultsFormat format)
+        public async Task GetReadResultsAsync(string path, ReadResultsFormat format)
         {
             using (var fileStream = File.OpenWrite(path))
             {
-                await GetReadResults(fileStream, format).ConfigureAwait(false);
+                await GetReadResultsAsync(fileStream, format).ConfigureAwait(false);
             }
         }
 
@@ -86,7 +86,7 @@ namespace Waives.Http
         /// <param name="format">The format of the results required</param>
         /// <remarks>The Read method must be called before this method, otherwise a
         /// WaivesApiException will be thrown.</remarks>
-        public async Task GetReadResults(Stream resultsStream, ReadResultsFormat format)
+        public async Task GetReadResultsAsync(Stream resultsStream, ReadResultsFormat format)
         {
             var readUrl = _behaviours["document:read"];
 
@@ -114,7 +114,7 @@ namespace Waives.Http
         /// </summary>
         /// <param name="classifierName">The name of the classifier to use.</param>
         /// <returns>The results of the classification operation.</returns>
-        public async Task<ClassificationResult> Classify(string classifierName)
+        public async Task<ClassificationResult> ClassifyAsync(string classifierName)
         {
             var classifyUrl = _behaviours["document:classify"];
 
@@ -135,15 +135,15 @@ namespace Waives.Http
         /// </summary>
         /// <param name="extractorName">The name of the extractor to use.</param>
         /// <returns>The results of the extraction operation.</returns>
-        public async Task<ExtractionResults> Extract(string extractorName)
+        public async Task<ExtractionResults> ExtractAsync(string extractorName)
         {
-            var extractionResponse = await DoExtraction(extractorName).ConfigureAwait(false);
+            var extractionResponse = await DoExtractionAsync(extractorName).ConfigureAwait(false);
             return await extractionResponse.ReadAsAsync<ExtractionResults>().ConfigureAwait(false);
         }
 
         /// <summary>
         /// Performs redaction on this document using results from an
-        /// <see cref="Extract" langword="extraction"/> operation using the
+        /// <see cref="ExtractAsync" langword="extraction"/> operation using the
         /// specified extractor name. The named extractor must already exist in
         /// the Waives platform. The result of this operation is a PDF file with
         /// the extracted data removed from the file.
@@ -156,10 +156,10 @@ namespace Waives.Http
         /// A <see cref="Stream"/> of bytes containing a PDF file. The returned
         /// Stream should be disposed of in your own code.
         /// </returns>
-        public async Task<Stream> Redact(string extractorName)
+        public async Task<Stream> RedactAsync(string extractorName)
         {
             var extractionResponse =
-                await DoExtraction(extractorName, RedactionRequest.MimeType)
+                await DoExtractionAsync(extractorName, RedactionRequest.MimeType)
                 .ConfigureAwait(false);
 
             var redactions = await extractionResponse.ReadAsStringAsync().ConfigureAwait(false);
@@ -172,7 +172,7 @@ namespace Waives.Http
             return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
-        private async Task<HttpContent> DoExtraction(string extractorName,
+        private async Task<HttpContent> DoExtractionAsync(string extractorName,
             string desiredResponseFormat = ExtractionResults.MimeType)
         {
             var extractUrl = _behaviours["document:extract"].CreateUri(new

--- a/src/Waives.Http/RequestHandling/AccessTokenService.cs
+++ b/src/Waives.Http/RequestHandling/AccessTokenService.cs
@@ -37,7 +37,7 @@ namespace Waives.Http.RequestHandling
                 });
         }
 
-        internal async Task<AccessToken> FetchAccessToken()
+        internal async Task<AccessToken> FetchAccessTokenAsync()
         {
             return await _cachePolicy.ExecuteAsync(async context =>
             {
@@ -52,7 +52,7 @@ namespace Waives.Http.RequestHandling
 
                 var response = await _requestSender.Send(request).ConfigureAwait(false);
                 return await response.Content.ReadAsAsync<AccessToken>().ConfigureAwait(false);
-            }, new Context(nameof(FetchAccessToken))).ConfigureAwait(false);
+            }, new Context(nameof(FetchAccessTokenAsync))).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Waives.Http/RequestHandling/AccessTokenService.cs
+++ b/src/Waives.Http/RequestHandling/AccessTokenService.cs
@@ -50,7 +50,7 @@ namespace Waives.Http.RequestHandling
                     })
                 };
 
-                var response = await _requestSender.Send(request).ConfigureAwait(false);
+                var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
                 return await response.Content.ReadAsAsync<AccessToken>().ConfigureAwait(false);
             }, new Context(nameof(FetchAccessTokenAsync))).ConfigureAwait(false);
         }

--- a/src/Waives.Http/RequestHandling/FailedRequestHandlingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/FailedRequestHandlingRequestSender.cs
@@ -19,9 +19,9 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
         {
-            var response = await _wrappedRequestSender.Send(request).ConfigureAwait(false);
+            var response = await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 return response;

--- a/src/Waives.Http/RequestHandling/IHttpRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/IHttpRequestSender.cs
@@ -7,6 +7,6 @@ namespace Waives.Http.RequestHandling
     {
         int Timeout { get; set; }
 
-        Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request);
     }
 }

--- a/src/Waives.Http/RequestHandling/LoggingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/LoggingRequestSender.cs
@@ -22,7 +22,7 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
         {
             var stopWatch = new Stopwatch();
             Logger.Trace("Sending {RequestMethod} request to {RequestUri}", request.Method, request.RequestUri);
@@ -30,7 +30,7 @@ namespace Waives.Http.RequestHandling
             try
             {
                 stopWatch.Start();
-                var response = await _wrappedRequestSender.Send(request).ConfigureAwait(false);
+                var response = await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
                 stopWatch.Stop();
 
                 Logger.Trace(

--- a/src/Waives.Http/RequestHandling/ReliableRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/ReliableRequestSender.cs
@@ -33,11 +33,11 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
         {
             return await _policy
                 .ExecuteAsync(() =>
-                    _wrappedRequestSender.Send(request))
+                    _wrappedRequestSender.SendAsync(request))
                 .ConfigureAwait(false);
         }
 

--- a/src/Waives.Http/RequestHandling/RequestSender.cs
+++ b/src/Waives.Http/RequestHandling/RequestSender.cs
@@ -28,7 +28,7 @@ namespace Waives.Http.RequestHandling
             set => _httpClient.Timeout = TimeSpan.FromSeconds(value);
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate template)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate template)
         {
             var request = template.CreateRequest();
             return await _httpClient.SendAsync(request).ConfigureAwait(false);

--- a/src/Waives.Http/RequestHandling/TimeoutHandlingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TimeoutHandlingRequestSender.cs
@@ -25,11 +25,11 @@ namespace Waives.Http.RequestHandling
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
         {
             try
             {
-                return await _wrappedRequestSender.Send(request).ConfigureAwait(false);
+                return await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
             }
             catch (Exception e) when (e is TaskCanceledException || e is OperationCanceledException)
             {

--- a/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
@@ -21,12 +21,12 @@ namespace Waives.Http.RequestHandling
             set => _requestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
         {
             var token = await _accessTokenService.FetchAccessTokenAsync().ConfigureAwait(false);
             request.Headers["Authorization"] = $"Bearer {token}";
 
-            return await _requestSender.Send(request).ConfigureAwait(false);
+            return await _requestSender.SendAsync(request).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
@@ -23,7 +23,7 @@ namespace Waives.Http.RequestHandling
 
         public async Task<HttpResponseMessage> Send(HttpRequestMessageTemplate request)
         {
-            var token = await _accessTokenService.FetchAccessToken().ConfigureAwait(false);
+            var token = await _accessTokenService.FetchAccessTokenAsync().ConfigureAwait(false);
             request.Headers["Authorization"] = $"Bearer {token}";
 
             return await _requestSender.Send(request).ConfigureAwait(false);

--- a/src/Waives.Http/Responses/ClassificationResponse.cs
+++ b/src/Waives.Http/Responses/ClassificationResponse.cs
@@ -13,7 +13,7 @@ namespace Waives.Http.Responses
     }
 
     /// <summary>
-    /// Represents the results of a <see cref="Document.Classify"/> operation.
+    /// Represents the results of a <see cref="Document.ClassifyAsync"/> operation.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -112,14 +112,14 @@ namespace Waives.Http
         /// The Waives platform implements a limit on the number of documents that may concurrently
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
-        /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
+        /// completed on them. It can be useful to use <see cref="GetAllDocumentsAsync"/> in conjunction
         /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="documentSource">The <see cref="Stream"/> source of the document.</param>
         /// <returns>A <see cref="Document"/> client for the given document.</returns>
         /// <seealso cref="Document"/>
         /// <seealso cref="Document.DeleteAsync"/>
-        public async Task<Document> CreateDocument(Stream documentSource)
+        public async Task<Document> CreateDocumentAsync(Stream documentSource)
         {
             if (documentSource == null)
             {
@@ -165,16 +165,16 @@ namespace Waives.Http
         /// The Waives platform implements a limit on the number of documents that may concurrently
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
-        /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
+        /// completed on them. It can be useful to use <see cref="GetAllDocumentsAsync"/> in conjunction
         /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="path">A path to a file on disk from which the document will be created.</param>
         /// <returns>A <see cref="Document"/> client for the given document.</returns>
         /// <seealso cref="Document"/>
         /// <seealso cref="Document.DeleteAsync"/>
-        public async Task<Document> CreateDocument(string path)
+        public async Task<Document> CreateDocumentAsync(string path)
         {
-            return await CreateDocument(File.OpenRead(path)).ConfigureAwait(false);
+            return await CreateDocumentAsync(File.OpenRead(path)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Waives.Http
         /// The Waives platform implements a limit on the number of documents that may concurrently
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
-        /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
+        /// completed on them. It can be useful to use <see cref="GetAllDocumentsAsync"/> in conjunction
         /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="uri">The HTTP(S) URI of a file, accessible to Waives, from which the document will be created.</param>
@@ -192,7 +192,7 @@ namespace Waives.Http
         /// <exception cref="ArgumentNullException">Thrown when the provided <see cref="Uri"/> is null.</exception>
         /// <seealso cref="Document"/>
         /// <seealso cref="Document.DeleteAsync"/>
-        public async Task<Document> CreateDocument(Uri uri)
+        public async Task<Document> CreateDocumentAsync(Uri uri)
         {
             uri = uri ?? throw new ArgumentNullException(nameof(uri));
 
@@ -218,9 +218,9 @@ namespace Waives.Http
         /// <summary>
         /// Fetch a reference for the given document in the Waives platform.
         /// </summary>
-        /// <param name="id">The ID of the document, as returned by <see cref="CreateDocument(Stream)"/>.</param>
+        /// <param name="id">The ID of the document, as returned by <see cref="CreateDocumentAsync(Stream)"/>.</param>
         /// <returns>A <see cref="Document"/> client for the specified document ID.</returns>
-        public async Task<Document> GetDocument(string id)
+        public async Task<Document> GetDocumentAsync(string id)
         {
             var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri($"/documents/{id}", UriKind.Relative));
             var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
@@ -236,12 +236,12 @@ namespace Waives.Http
         /// The Waives platform implements a limit on the number of documents that may concurrently
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
-        /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
+        /// completed on them. It can be useful to use <see cref="GetAllDocumentsAsync"/> in conjunction
         /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <returns>An <see cref="IEnumerable{Document}"/> representing all the documents
         /// created in your account.</returns>
-        public async Task<IEnumerable<Document>> GetAllDocuments()
+        public async Task<IEnumerable<Document>> GetAllDocumentsAsync()
         {
             var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
             var response = await _requestSender.SendAsync(request).ConfigureAwait(false);

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -113,12 +113,12 @@ namespace Waives.Http
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
         /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
-        /// with <see cref="Document.Delete"/> to ensure you are starting from a clean slate.
+        /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="documentSource">The <see cref="Stream"/> source of the document.</param>
         /// <returns>A <see cref="Document"/> client for the given document.</returns>
         /// <seealso cref="Document"/>
-        /// <seealso cref="Document.Delete"/>
+        /// <seealso cref="Document.DeleteAsync"/>
         public async Task<Document> CreateDocument(Stream documentSource)
         {
             if (documentSource == null)
@@ -166,12 +166,12 @@ namespace Waives.Http
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
         /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
-        /// with <see cref="Document.Delete"/> to ensure you are starting from a clean slate.
+        /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="path">A path to a file on disk from which the document will be created.</param>
         /// <returns>A <see cref="Document"/> client for the given document.</returns>
         /// <seealso cref="Document"/>
-        /// <seealso cref="Document.Delete"/>
+        /// <seealso cref="Document.DeleteAsync"/>
         public async Task<Document> CreateDocument(string path)
         {
             return await CreateDocument(File.OpenRead(path)).ConfigureAwait(false);
@@ -185,13 +185,13 @@ namespace Waives.Http
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
         /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
-        /// with <see cref="Document.Delete"/> to ensure you are starting from a clean slate.
+        /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <param name="uri">The HTTP(S) URI of a file, accessible to Waives, from which the document will be created.</param>
         /// <returns>A <see cref="Document"/> client for the given document.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the provided <see cref="Uri"/> is null.</exception>
         /// <seealso cref="Document"/>
-        /// <seealso cref="Document.Delete"/>
+        /// <seealso cref="Document.DeleteAsync"/>
         public async Task<Document> CreateDocument(Uri uri)
         {
             uri = uri ?? throw new ArgumentNullException(nameof(uri));
@@ -237,7 +237,7 @@ namespace Waives.Http
         /// exist within your account. It is expected that documents will exist only transiently
         /// within the Waives platform, and must be deleted after all desired operations have been
         /// completed on them. It can be useful to use <see cref="GetAllDocuments"/> in conjunction
-        /// with <see cref="Document.Delete"/> to ensure you are starting from a clean slate.
+        /// with <see cref="Document.DeleteAsync"/> to ensure you are starting from a clean slate.
         /// </remarks>
         /// <returns>An <see cref="IEnumerable{Document}"/> representing all the documents
         /// created in your account.</returns>

--- a/src/Waives.Http/WaivesClient.cs
+++ b/src/Waives.Http/WaivesClient.cs
@@ -152,7 +152,7 @@ namespace Waives.Http
                     Content = new StreamContent(documentSource)
                 };
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
             var document = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
 
             return new Document(_requestSender, document.Id, document.Links);
@@ -206,7 +206,7 @@ namespace Waives.Http
 
                 };
 
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
 
             var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
             var id = responseContent.Id;
@@ -223,7 +223,7 @@ namespace Waives.Http
         public async Task<Document> GetDocument(string id)
         {
             var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri($"/documents/{id}", UriKind.Relative));
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
 
             var responseContent = await response.Content.ReadAsAsync<HalResponse>().ConfigureAwait(false);
             return new Document(_requestSender, responseContent.Id, responseContent.Links);
@@ -244,7 +244,7 @@ namespace Waives.Http
         public async Task<IEnumerable<Document>> GetAllDocuments()
         {
             var request = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
-            var response = await _requestSender.Send(request).ConfigureAwait(false);
+            var response = await _requestSender.SendAsync(request).ConfigureAwait(false);
 
             var responseContent = await response.Content.ReadAsAsync<DocumentCollection>().ConfigureAwait(false);
             return responseContent.Documents.Select(d => new Document(_requestSender, d.Id, d.Links));

--- a/src/Waives.Pipelines/DocumentProcessor.cs
+++ b/src/Waives.Pipelines/DocumentProcessor.cs
@@ -29,7 +29,7 @@ namespace Waives.Pipelines
             try
             {
                 waivesDocument = await _docCreator(document);
-                await RunActions(waivesDocument).ConfigureAwait(false);
+                await RunActionsAsync(waivesDocument).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -44,7 +44,7 @@ namespace Waives.Pipelines
             }
         }
 
-        private async Task RunActions(WaivesDocument document)
+        private async Task RunActionsAsync(WaivesDocument document)
         {
             foreach (var docAction in _docActions)
             {

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -41,22 +41,22 @@ namespace Waives.Pipelines.HttpAdapters
 
         public async Task<ClassificationResult> Classify(string classifierName)
         {
-            return await _documentClient.Classify(classifierName).ConfigureAwait(false);
+            return await _documentClient.ClassifyAsync(classifierName).ConfigureAwait(false);
         }
 
         public async Task<ExtractionResults> Extract(string extractorName)
         {
-            return await _documentClient.Extract(extractorName).ConfigureAwait(false);
+            return await _documentClient.ExtractAsync(extractorName).ConfigureAwait(false);
         }
 
         public async Task<Stream> Redact(string extractorName)
         {
-            return await _documentClient.Redact(extractorName).ConfigureAwait(false);
+            return await _documentClient.RedactAsync(extractorName).ConfigureAwait(false);
         }
 
         public async Task Delete()
         {
-            await _documentClient.Delete().ConfigureAwait(false);
+            await _documentClient.DeleteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -11,13 +11,13 @@ namespace Waives.Pipelines.HttpAdapters
     /// </summary>
     internal interface IHttpDocument
     {
-        Task<ClassificationResult> Classify(string classifierName);
+        Task<ClassificationResult> ClassifyAsync(string classifierName);
 
-        Task<ExtractionResults> Extract(string extractorName);
+        Task<ExtractionResults> ExtractAsync(string extractorName);
 
-        Task<Stream> Redact(string extractorName);
+        Task<Stream> RedactAsync(string extractorName);
 
-        Task Delete();
+        Task DeleteAsync();
 
         string Id { get; }
     }
@@ -39,22 +39,22 @@ namespace Waives.Pipelines.HttpAdapters
             _documentClient = documentClient;
         }
 
-        public async Task<ClassificationResult> Classify(string classifierName)
+        public async Task<ClassificationResult> ClassifyAsync(string classifierName)
         {
             return await _documentClient.ClassifyAsync(classifierName).ConfigureAwait(false);
         }
 
-        public async Task<ExtractionResults> Extract(string extractorName)
+        public async Task<ExtractionResults> ExtractAsync(string extractorName)
         {
             return await _documentClient.ExtractAsync(extractorName).ConfigureAwait(false);
         }
 
-        public async Task<Stream> Redact(string extractorName)
+        public async Task<Stream> RedactAsync(string extractorName)
         {
             return await _documentClient.RedactAsync(extractorName).ConfigureAwait(false);
         }
 
-        public async Task Delete()
+        public async Task DeleteAsync()
         {
             await _documentClient.DeleteAsync().ConfigureAwait(false);
         }

--- a/src/Waives.Pipelines/HttpAdapters/LoggingDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/LoggingDocumentFactory.cs
@@ -14,9 +14,9 @@ namespace Waives.Pipelines.HttpAdapters
             _wrappedDocumentFactory = underlyingDocumentFactory;
         }
 
-        public async Task<IHttpDocument> CreateDocument(Document source)
+        public async Task<IHttpDocument> CreateDocumentAsync(Document source)
         {
-            var httpDocument = await _wrappedDocumentFactory.CreateDocument(source).ConfigureAwait(false);
+            var httpDocument = await _wrappedDocumentFactory.CreateDocumentAsync(source).ConfigureAwait(false);
 
             Logger.Info(
                 "Created Waives document {DocumentId} from '{DocumentSourceId}'",

--- a/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
@@ -31,7 +31,7 @@ namespace Waives.Pipelines.HttpAdapters
         {
             using (var documentStream = await source.OpenStream().ConfigureAwait(false))
             {
-                var httpDocument = new HttpDocument(await _apiClient.CreateDocument(documentStream).ConfigureAwait(false));
+                var httpDocument = new HttpDocument(await _apiClient.CreateDocumentAsync(documentStream).ConfigureAwait(false));
                 return httpDocument;
             }
         }
@@ -49,7 +49,7 @@ namespace Waives.Pipelines.HttpAdapters
 
         private static async Task DeleteOrphanedDocuments(WaivesClient apiClient)
         {
-            var orphanedDocuments = await apiClient.GetAllDocuments().ConfigureAwait(false);
+            var orphanedDocuments = await apiClient.GetAllDocumentsAsync().ConfigureAwait(false);
             await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync())).ConfigureAwait(false);
         }
     }

--- a/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
@@ -50,7 +50,7 @@ namespace Waives.Pipelines.HttpAdapters
         private static async Task DeleteOrphanedDocuments(WaivesClient apiClient)
         {
             var orphanedDocuments = await apiClient.GetAllDocuments().ConfigureAwait(false);
-            await Task.WhenAll(orphanedDocuments.Select(d => d.Delete())).ConfigureAwait(false);
+            await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync())).ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
@@ -10,7 +10,7 @@ namespace Waives.Pipelines.HttpAdapters
     /// </summary>
     internal interface IHttpDocumentFactory
     {
-        Task<IHttpDocument> CreateDocument(Document source);
+        Task<IHttpDocument> CreateDocumentAsync(Document source);
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ namespace Waives.Pipelines.HttpAdapters
             _apiClient = apiClient;
         }
 
-        public async Task<IHttpDocument> CreateDocument(Document source)
+        public async Task<IHttpDocument> CreateDocumentAsync(Document source)
         {
             using (var documentStream = await source.OpenStream().ConfigureAwait(false))
             {
@@ -36,18 +36,18 @@ namespace Waives.Pipelines.HttpAdapters
             }
         }
 
-        internal static async Task<IHttpDocumentFactory> Create(WaivesClient apiClient, bool deleteOrphanedDocuments = true)
+        internal static async Task<IHttpDocumentFactory> CreateAsync(WaivesClient apiClient, bool deleteOrphanedDocuments = true)
         {
             if (deleteOrphanedDocuments)
             {
-                await DeleteOrphanedDocuments(apiClient).ConfigureAwait(false);
+                await DeleteOrphanedDocumentsAsync(apiClient).ConfigureAwait(false);
                 Logger.Info("Deleted all Waives documents");
             }
 
             return new LoggingDocumentFactory(new HttpDocumentFactory(apiClient));
         }
 
-        private static async Task DeleteOrphanedDocuments(WaivesClient apiClient)
+        private static async Task DeleteOrphanedDocumentsAsync(WaivesClient apiClient)
         {
             var orphanedDocuments = await apiClient.GetAllDocumentsAsync().ConfigureAwait(false);
             await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync())).ConfigureAwait(false);

--- a/src/Waives.Pipelines/ObservableProcessExtension.cs
+++ b/src/Waives.Pipelines/ObservableProcessExtension.cs
@@ -20,7 +20,7 @@ namespace Waives.Pipelines
                 }
                 catch (Exception e)
                 {
-                    var documentError = await OnProcessingError(
+                    var documentError = await OnProcessingErrorAsync(
                         new ProcessingError<TDocument>(d, e)).ConfigureAwait(false);
 
                     errorAction(documentError);
@@ -32,7 +32,7 @@ namespace Waives.Pipelines
             return results.Select(r => r.Document);
         }
 
-        private static async Task<DocumentError> OnProcessingError<TDocument>(ProcessingError<TDocument> error)
+        private static async Task<DocumentError> OnProcessingErrorAsync<TDocument>(ProcessingError<TDocument> error)
         {
             // Try coercing the document in error to a Waives Document. If it is, it
             // has been created in the platform and must be deleted before proceeding.

--- a/src/Waives.Pipelines/ObservableProcessExtension.cs
+++ b/src/Waives.Pipelines/ObservableProcessExtension.cs
@@ -39,7 +39,7 @@ namespace Waives.Pipelines
             var waivesDocument = error.Document as WaivesDocument;
             if (waivesDocument != null)
             {
-                await waivesDocument.Delete().ConfigureAwait(false);
+                await waivesDocument.DeleteAsync().ConfigureAwait(false);
                 return new DocumentError(waivesDocument.Source, error.Exception);
             }
 

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -106,7 +106,7 @@ namespace Waives.Pipelines
         {
             _docActions.Add(async d =>
             {
-                var document = await d.Classify(classifierName)
+                var document = await d.ClassifyAsync(classifierName)
                     .ConfigureAwait(false);
 
                 _logger.Info(
@@ -128,7 +128,7 @@ namespace Waives.Pipelines
         {
             _docActions.Add(async d =>
             {
-                var document = await d.Extract(extractorName).ConfigureAwait(false);
+                var document = await d.ExtractAsync(extractorName).ConfigureAwait(false);
                 _logger.Info(
                     "Extracted data from document {DocumentId} from '{DocumentSource}'",
                     d.Id,
@@ -201,7 +201,7 @@ namespace Waives.Pipelines
         {
             _docActions.Add(async d =>
             {
-                var document = await d.Redact(extractorName, resultFunc).ConfigureAwait(false);
+                var document = await d.RedactAsync(extractorName, resultFunc).ConfigureAwait(false);
                 _logger.Info(
                     "Redacted data from document {DocumentId} from '{DocumentSource}' using extractor '{ExtractorName}'",
                     d.Id,

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -340,7 +340,7 @@ namespace Waives.Pipelines
             {
                 try
                 {
-                    await d.HttpDocument.Delete().ConfigureAwait(false);
+                    await d.HttpDocument.DeleteAsync().ConfigureAwait(false);
 
                     _logger.Info(
                         "Deleted document {DocumentId}. Processing of '{DocumentSourceId}' complete.",

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -331,7 +331,7 @@ namespace Waives.Pipelines
                 _logger.Info("Started processing '{DocumentSourceId}'", d.SourceId);
 
                 var httpDocument = await _documentFactory
-                    .CreateDocument(d).ConfigureAwait(false);
+                    .CreateDocumentAsync(d).ConfigureAwait(false);
 
                 return new WaivesDocument(d, httpDocument);
             };

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -62,7 +62,7 @@ namespace Waives.Pipelines
         {
             var waivesClient = CreateAuthenticatedWaivesClient(options);
 
-            var documentFactory = await HttpDocumentFactory.Create(
+            var documentFactory = await HttpDocumentFactory.CreateAsync(
                 waivesClient,
                 options.DeleteExistingDocuments).ConfigureAwait(false);
 

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -58,7 +58,7 @@ namespace Waives.Pipelines
         /// <param name="options"></param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
-        public static async Task<Pipeline> CreatePipeline(WaivesOptions options)
+        public static async Task<Pipeline> CreatePipelineAsync(WaivesOptions options)
         {
             var waivesClient = CreateAuthenticatedWaivesClient(options);
 

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -29,7 +29,7 @@ namespace Waives.Pipelines
 
         public ExtractionResults ExtractionResults { get; private set; }
 
-        public async Task<WaivesDocument> Classify(string classifierName)
+        public async Task<WaivesDocument> ClassifyAsync(string classifierName)
         {
             return new WaivesDocument(Source, _waivesDocument)
             {
@@ -38,7 +38,7 @@ namespace Waives.Pipelines
             };
         }
 
-        public async Task<WaivesDocument> Extract(string extractorName)
+        public async Task<WaivesDocument> ExtractAsync(string extractorName)
         {
             return new WaivesDocument(Source, _waivesDocument)
             {
@@ -47,7 +47,7 @@ namespace Waives.Pipelines
             };
         }
 
-        public async Task<WaivesDocument> Redact(string extractorName, Func<WaivesDocument, Stream, Task> resultFunc)
+        public async Task<WaivesDocument> RedactAsync(string extractorName, Func<WaivesDocument, Stream, Task> resultFunc)
         {
             if (string.IsNullOrWhiteSpace(extractorName))
             {
@@ -65,7 +65,7 @@ namespace Waives.Pipelines
             return this;
         }
 
-        public async Task Delete()
+        public async Task DeleteAsync()
         {
             await _waivesDocument.DeleteAsync().ConfigureAwait(false);
         }

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -33,7 +33,7 @@ namespace Waives.Pipelines
         {
             return new WaivesDocument(Source, _waivesDocument)
             {
-                ClassificationResults = await _waivesDocument.Classify(classifierName).ConfigureAwait(false),
+                ClassificationResults = await _waivesDocument.ClassifyAsync(classifierName).ConfigureAwait(false),
                 ExtractionResults = ExtractionResults
             };
         }
@@ -43,7 +43,7 @@ namespace Waives.Pipelines
             return new WaivesDocument(Source, _waivesDocument)
             {
                 ClassificationResults = ClassificationResults,
-                ExtractionResults = await _waivesDocument.Extract(extractorName).ConfigureAwait(false)
+                ExtractionResults = await _waivesDocument.ExtractAsync(extractorName).ConfigureAwait(false)
             };
         }
 
@@ -59,7 +59,7 @@ namespace Waives.Pipelines
                 throw new ArgumentNullException(nameof(resultFunc));
             }
 
-            var resultStream = await _waivesDocument.Redact(extractorName);
+            var resultStream = await _waivesDocument.RedactAsync(extractorName);
             await resultFunc(this, resultStream);
 
             return this;
@@ -67,7 +67,7 @@ namespace Waives.Pipelines
 
         public async Task Delete()
         {
-            await _waivesDocument.Delete().ConfigureAwait(false);
+            await _waivesDocument.DeleteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -60,14 +60,14 @@ namespace Waives.Http.Tests
         public async Task Delete_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.DeleteAsync();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Delete &&
                     m.RequestUri.ToString() == _selfUrl));
         }
@@ -77,7 +77,7 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.DeleteAsync());
@@ -88,14 +88,14 @@ namespace Waives.Http.Tests
         public async Task Read_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.ReadAsync();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Put &&
                     m.RequestUri.ToString() == _readUrl));
         }
@@ -105,7 +105,7 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ReadAsync());
@@ -119,14 +119,14 @@ namespace Waives.Http.Tests
         public async Task Get_read_results_sends_request_with_correct_url(ReadResultsFormat format, string expectedAcceptHeader)
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetReadResults(ci.Arg<HttpRequestMessageTemplate>(), $"Anonymous string {Guid.NewGuid()}"));
 
             await _sut.GetReadResultsAsync(_readResultsFilename, format);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
                     m.RequestUri.ToString() == _readUrl &&
                     m.Headers.Contains(new KeyValuePair<string, string>("Accept", expectedAcceptHeader))));
@@ -137,7 +137,7 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.GetReadResultsAsync(_readResultsFilename, ReadResultsFormat.Pdf));
@@ -150,7 +150,7 @@ namespace Waives.Http.Tests
             var readResults = $"Read results {Guid.NewGuid()}";
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetReadResults(ci.Arg<HttpRequestMessageTemplate>(), readResults));
 
             using (var resultsStream = new MemoryStream())
@@ -169,7 +169,7 @@ namespace Waives.Http.Tests
             var readResults = $"Read results {Guid.NewGuid()}";
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetReadResults(ci.Arg<HttpRequestMessageTemplate>(), readResults));
 
             await _sut.GetReadResultsAsync(_readResultsFilename, ReadResultsFormat.Text);
@@ -182,14 +182,14 @@ namespace Waives.Http.Tests
         public async Task Classify_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.ClassifyAsync(_classifierName);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == _classifyUrl));
         }
@@ -198,7 +198,7 @@ namespace Waives.Http.Tests
         public async Task Classify_returns_a_result_with_correct_properties_set()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
             var result = await _sut.ClassifyAsync(_classifierName);
@@ -216,7 +216,7 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ClassifyAsync(_classifierName));
@@ -228,14 +228,14 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.ExtractAsync(_extractorName);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == _extractUrl));
         }
@@ -244,7 +244,7 @@ namespace Waives.Http.Tests
         public async Task Extract_returns_a_result_with_correct_properties_set()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             var response = await _sut.ExtractAsync(_extractorName);
@@ -287,7 +287,7 @@ namespace Waives.Http.Tests
         {
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ExtractAsync(_extractorName));
@@ -298,18 +298,18 @@ namespace Waives.Http.Tests
         public async Task Redact_sends_request_with_correct_url()
         {
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.RedactAsync(_extractorName);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == _redactUrl));
         }
@@ -318,11 +318,11 @@ namespace Waives.Http.Tests
         public async Task Redact_returns_a_stream()
         {
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
             var response = await _sut.RedactAsync(_extractorName);
@@ -337,12 +337,12 @@ namespace Waives.Http.Tests
         public async Task Redact_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             var exceptionMessage = $"Anonymous string {Guid.NewGuid()}";
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Throws(new WaivesApiException(exceptionMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.RedactAsync(_extractorName));
@@ -353,18 +353,18 @@ namespace Waives.Http.Tests
         public async Task Redact_uses_extraction_results_for_redaction()
         {
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("extract")))
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.RedactAsync(_extractorName);
 
             await _requestSender
                 .Received(1)
-                .Send(
+                .SendAsync(
                     Arg.Is<HttpRequestMessageTemplate>(
                         t => new HttpContentEqualityComparer().Equals(
                             t.Content,

--- a/test/Waives.Http.Tests/DocumentFacts.cs
+++ b/test/Waives.Http.Tests/DocumentFacts.cs
@@ -63,7 +63,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Delete();
+            await _sut.DeleteAsync();
 
             await _requestSender
                 .Received(1)
@@ -80,7 +80,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Delete());
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.DeleteAsync());
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -91,7 +91,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Read();
+            await _sut.ReadAsync();
 
             await _requestSender
                 .Received(1)
@@ -108,7 +108,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Read());
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ReadAsync());
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -122,7 +122,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetReadResults(ci.Arg<HttpRequestMessageTemplate>(), $"Anonymous string {Guid.NewGuid()}"));
 
-            await _sut.GetReadResults(_readResultsFilename, format);
+            await _sut.GetReadResultsAsync(_readResultsFilename, format);
 
             await _requestSender
                 .Received(1)
@@ -140,7 +140,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.GetReadResults(_readResultsFilename, ReadResultsFormat.Pdf));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.GetReadResultsAsync(_readResultsFilename, ReadResultsFormat.Pdf));
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -156,7 +156,7 @@ namespace Waives.Http.Tests
             using (var resultsStream = new MemoryStream())
             using (var sr = new StreamReader(resultsStream))
             {
-                await _sut.GetReadResults(resultsStream, ReadResultsFormat.Text);
+                await _sut.GetReadResultsAsync(resultsStream, ReadResultsFormat.Text);
 
                 resultsStream.Position = 0;
                 Assert.Equal(readResults, sr.ReadToEnd());
@@ -172,7 +172,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetReadResults(ci.Arg<HttpRequestMessageTemplate>(), readResults));
 
-            await _sut.GetReadResults(_readResultsFilename, ReadResultsFormat.Text);
+            await _sut.GetReadResultsAsync(_readResultsFilename, ReadResultsFormat.Text);
 
 
             Assert.Equal(readResults, await File.ReadAllTextAsync(_readResultsFilename));
@@ -185,7 +185,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Classify(_classifierName);
+            await _sut.ClassifyAsync(_classifierName);
 
             await _requestSender
                 .Received(1)
@@ -201,7 +201,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
-            var result = await _sut.Classify(_classifierName);
+            var result = await _sut.ClassifyAsync(_classifierName);
 
             Assert.Equal("expectedDocumentType", result.DocumentType);
             Assert.Equal(2.85512137M, result.RelativeConfidence);
@@ -219,7 +219,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Classify(_classifierName));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ClassifyAsync(_classifierName));
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -231,7 +231,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Extract(_extractorName);
+            await _sut.ExtractAsync(_extractorName);
 
             await _requestSender
                 .Received(1)
@@ -247,7 +247,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Extract(ci.Arg<HttpRequestMessageTemplate>()));
 
-            var response = await _sut.Extract(_extractorName);
+            var response = await _sut.ExtractAsync(_extractorName);
 
 
             var extractionPage = response.DocumentMetadata.Pages.First();
@@ -290,7 +290,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Extract(_extractorName));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.ExtractAsync(_extractorName));
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -305,7 +305,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Redact(_extractorName);
+            await _sut.RedactAsync(_extractorName);
 
             await _requestSender
                 .Received(1)
@@ -325,7 +325,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
-            var response = await _sut.Redact(_extractorName);
+            var response = await _sut.RedactAsync(_extractorName);
 
             var result = new byte[3].AsMemory();
             response.Read(result.Span);
@@ -345,7 +345,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Throws(new WaivesApiException(exceptionMessage));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Redact(_extractorName));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.RedactAsync(_extractorName));
             Assert.Equal(exceptionMessage, exception.Message);
         }
 
@@ -360,7 +360,7 @@ namespace Waives.Http.Tests
                 .Send(Arg.Is<HttpRequestMessageTemplate>(t => t.RequestUri.ToString().Contains("redact")))
                 .Returns(ci => Response.Redact(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Redact(_extractorName);
+            await _sut.RedactAsync(_extractorName);
 
             await _requestSender
                 .Received(1)

--- a/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
@@ -30,7 +30,7 @@ namespace Waives.Http.Tests.RequestHandling
                 .Send(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetToken(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.FetchAccessToken();
+            await _sut.FetchAccessTokenAsync();
 
             await _requestSender
                 .Received(1)
@@ -47,7 +47,7 @@ namespace Waives.Http.Tests.RequestHandling
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.FetchAccessToken());
+                _sut.FetchAccessTokenAsync());
 
             Assert.Equal(Response.ErrorMessage, exception.Message);
         }

--- a/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/AccessTokenServiceFacts.cs
@@ -27,14 +27,14 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Login_sends_a_request_with_the_specified_credentials()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetToken(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.FetchAccessTokenAsync();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     IsFormWithClientCredentials(m.Content, ExpectedClientId, ExpectedClientSecret)));
         }
@@ -43,7 +43,7 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Login_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>

--- a/test/Waives.Http.Tests/RequestHandling/FailedRequestHandlingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/FailedRequestHandlingRequestSenderFacts.cs
@@ -25,10 +25,10 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Throw_WaivesApiException_on_failed_requests(HttpStatusCode statusCode)
         {
             _requestSender
-                .Send(_request)
+                .SendAsync(_request)
                 .ReturnsForAnyArgs(Response.ErrorFrom(statusCode, _request));
 
-            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.Send(_request));
+            var exception = await Assert.ThrowsAsync<WaivesApiException>(() => _sut.SendAsync(_request));
             Assert.Equal(Response.ErrorMessage, exception.Message);
         }
 
@@ -37,10 +37,10 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var expected = Response.SuccessFrom(statusCode, _request);
             _requestSender
-                .Send(_request)
+                .SendAsync(_request)
                 .ReturnsForAnyArgs(expected);
 
-            var actual = await _sut.Send(_request);
+            var actual = await _sut.SendAsync(_request);
 
             Assert.Equal(expected, actual);
         }

--- a/test/Waives.Http.Tests/RequestHandling/LoggingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/LoggingRequestSenderFacts.cs
@@ -34,10 +34,10 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var expectedResponse = Response.Success(_request);
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(expectedResponse);
 
-            var response = await _sut.Send(_request);
+            var response = await _sut.SendAsync(_request);
 
             Assert.Same(expectedResponse, response);
         }
@@ -47,11 +47,11 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var expectedException = new WaivesApiException();
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(expectedException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
 
             Assert.Same(expectedException, actualException);
         }
@@ -60,10 +60,10 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Logs_a_sending_request_message_when_request_is_successful()
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Send(_request);
+            await _sut.SendAsync(_request);
 
             _logEvents
                 .HasMessage("Sending {RequestMethod} request to {RequestUri}")
@@ -78,11 +78,11 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var exception = new WaivesApiException("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
 
             _logEvents
                 .HasMessage("Sending {RequestMethod} request to {RequestUri}")
@@ -96,10 +96,10 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Logs_a_received_response_message_when_request_is_successful()
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.Send(_request);
+            await _sut.SendAsync(_request);
 
             _logEvents
                 .HasMessage("Received response from {RequestMethod} {RequestUri} ({StatusCode}) ({ElapsedMilliseconds} ms)")
@@ -116,11 +116,11 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var exception = new WaivesApiException("an error message");
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
 
             _logEvents
                 .HasMessage(exception.Message)
@@ -136,11 +136,11 @@ namespace Waives.Http.Tests.RequestHandling
             var exception = new WaivesApiException("an error message", innerException);
 
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(exception);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
 
             _logEvents
                 .HasMessage("{Message} Inner exception: {InnerExceptionMessage}")

--- a/test/Waives.Http.Tests/RequestHandling/ReliableRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/ReliableRequestSenderFacts.cs
@@ -43,14 +43,14 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var sender = Substitute.For<IHttpRequestSender>();
             sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(
                     ci => Response.From(statusCode, ci.Arg<HttpRequestMessageTemplate>()),
                     ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
             var sut = new ReliableRequestSender(sender);
 
-            await sut.Send(_request);
+            await sut.SendAsync(_request);
 
             _logEvents
                 .HasMessage("Request '{RequestMethod} {RequestUri}' failed with " +
@@ -70,14 +70,14 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var sender = Substitute.For<IHttpRequestSender>();
             sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(
                     ci => new HttpResponseMessage(statusCode),
                     ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
             var sut = new ReliableRequestSender(sender);
 
-            await sut.Send(_request);
+            await sut.SendAsync(_request);
 
             Assert.Empty(_logEvents);
         }
@@ -88,20 +88,20 @@ namespace Waives.Http.Tests.RequestHandling
             var request = ARequestWithContentAndHeader();
 
             var sender = Substitute.For<IHttpRequestSender>();
-            sender.Send(Arg.Any<HttpRequestMessageTemplate>())
+            sender.SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
             var sut = new ReliableRequestSender(sender);
 
-            await sut.Send(request);
+            await sut.SendAsync(request);
 
             await sender
                 .Received(1)
-                .Send(Arg.Any<HttpRequestMessageTemplate>());
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>());
 
             await sender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     RequestsAreEqual(request, m)));
         }
 

--- a/test/Waives.Http.Tests/RequestHandling/TimeoutHandlingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/TimeoutHandlingRequestSenderFacts.cs
@@ -28,10 +28,10 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var expectedResponse = Response.Success(_request);
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(expectedResponse);
 
-            var response = await _sut.Send(_request);
+            var response = await _sut.SendAsync(_request);
 
             Assert.Same(expectedResponse, response);
         }
@@ -41,11 +41,11 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Throws_WaivesApiException_if_wrapped_sender_times_out(Exception senderException)
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(senderException);
 
             await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
         }
 
         [Theory]
@@ -53,11 +53,11 @@ namespace Waives.Http.Tests.RequestHandling
         public async Task Includes_request_details_in_exception_if_wrapped_sender_times_out(Exception senderException)
         {
             _sender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(senderException);
 
             var actualException = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.Send(_request));
+                _sut.SendAsync(_request));
 
             Assert.Contains(_request.Method.ToString(), actualException.Message);
             Assert.Contains(_request.RequestUri.ToString(), actualException.Message);

--- a/test/Waives.Http.Tests/RequestHandling/TokenFetchingRequestSenderFacts.cs
+++ b/test/Waives.Http.Tests/RequestHandling/TokenFetchingRequestSenderFacts.cs
@@ -21,7 +21,7 @@ namespace Waives.Http.Tests.RequestHandling
                 _requestSender);
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(
                     r => !r.Headers.ContainsKey("Authorization")))
                 .Returns(ci => Response.GetToken(ci.Arg<HttpRequestMessageTemplate>()));
         }
@@ -29,23 +29,23 @@ namespace Waives.Http.Tests.RequestHandling
         [Fact]
         public async Task Send_retrieves_an_access_token_for_the_request()
         {
-            await _sut.Send(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
+            await _sut.SendAsync(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(
                     r => r.RequestUri == new Uri("/oauth/token", UriKind.Relative)));
         }
 
         [Fact]
         public async Task Send_retrieves_an_access_token_only_once_while_the_token_is_valid()
         {
-            await _sut.Send(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
-            await _sut.Send(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
-            await _sut.Send(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
+            await _sut.SendAsync(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
+            await _sut.SendAsync(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
+            await _sut.SendAsync(new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative)));
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(
                     r => r.RequestUri == new Uri("/oauth/token", UriKind.Relative)));
         }
 
@@ -54,11 +54,11 @@ namespace Waives.Http.Tests.RequestHandling
         {
             var template = new HttpRequestMessageTemplate(HttpMethod.Get, new Uri("/documents", UriKind.Relative));
 
-            await _sut.Send(template);
+            await _sut.SendAsync(template);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(
                     r => r.RequestUri == template.RequestUri &&
                          r.Headers.ContainsKey("Authorization")));
         }

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -145,13 +145,13 @@ namespace Waives.Http.Tests
                     .Send(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
-                await document.Classify("classifier");
+                await document.ClassifyAsync("classifier");
 
                 _requestSender
                     .Send(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
-                await document.Delete();
+                await document.DeleteAsync();
             }
         }
 

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -30,7 +30,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_sends_a_request_to_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             using (var stream = new MemoryStream(_documentContents))
@@ -40,7 +40,7 @@ namespace Waives.Http.Tests
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Post &&
                     m.RequestUri.ToString() == "/documents"));
         }
@@ -49,7 +49,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_sends_the_supplied_stream_as_content()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             using (var stream = new MemoryStream(_documentContents))
@@ -58,7 +58,7 @@ namespace Waives.Http.Tests
 
                 await _requestSender
                     .Received(1)
-                    .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                    .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                         RequestContentEquals(m, _documentContents)));
             }
         }
@@ -67,7 +67,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_sends_the_supplied_unseekable_stream_as_content()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             using (var stream = new UnseekableMemoryStream(_documentContents))
@@ -76,7 +76,7 @@ namespace Waives.Http.Tests
 
                 await _requestSender
                     .Received(1)
-                    .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                    .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                         RequestContentEquals(m, _documentContents)));
             }
         }
@@ -87,18 +87,18 @@ namespace Waives.Http.Tests
             const string filePath = "DummyDocument.txt";
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             _requestSender
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m => m.RequestUri.ToString().Contains("/classify")))
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m => m.RequestUri.ToString().Contains("/classify")))
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.CreateDocument(filePath);
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     RequestContentEquals(m, File.ReadAllBytes(filePath))));
         }
 
@@ -108,7 +108,7 @@ namespace Waives.Http.Tests
             var fileUri = new Uri("https://myfileserver.com/mydocument.pdf");
 
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.CreateDocument(fileUri);
@@ -122,7 +122,7 @@ namespace Waives.Http.Tests
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     RequestContentEquals(m, expectedContents) &&
                     m.Method == HttpMethod.Post &&
                     m.Content.Headers.ContentType.MediaType == "application/json"));
@@ -132,7 +132,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_returns_a_document_that_can_be_used()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             using (var stream = new MemoryStream(_documentContents))
@@ -142,13 +142,13 @@ namespace Waives.Http.Tests
                 Assert.Equal("expectedDocumentId", document.Id);
 
                 _requestSender
-                    .Send(Arg.Any<HttpRequestMessageTemplate>())
+                    .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
                 await document.ClassifyAsync("classifier");
 
                 _requestSender
-                    .Send(Arg.Any<HttpRequestMessageTemplate>())
+                    .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                     .Returns(ci => Response.Success(ci.Arg<HttpRequestMessageTemplate>()));
 
                 await document.DeleteAsync();
@@ -159,7 +159,7 @@ namespace Waives.Http.Tests
         public async Task CreateDocument_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             using (var stream = new MemoryStream(_documentContents))
@@ -198,7 +198,7 @@ namespace Waives.Http.Tests
         public async Task GetDocument_sends_a_request_to_the_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             var documentId = $"anonymousString{Guid.NewGuid()}";
@@ -206,7 +206,7 @@ namespace Waives.Http.Tests
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
                     m.RequestUri.ToString() == $"/documents/{documentId}"));
         }
@@ -215,7 +215,7 @@ namespace Waives.Http.Tests
         public async Task GetDocument_returns_the_requested_document()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             var document = await _sut.GetDocument($"anonymousString{Guid.NewGuid()}");
@@ -227,7 +227,7 @@ namespace Waives.Http.Tests
         public async Task GetDocument_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
@@ -240,14 +240,14 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_sends_a_request_to_correct_url()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetAllDocuments(ci.Arg<HttpRequestMessageTemplate>()));
 
             await _sut.GetAllDocuments();
 
             await _requestSender
                 .Received(1)
-                .Send(Arg.Is<HttpRequestMessageTemplate>(m =>
+                .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m =>
                     m.Method == HttpMethod.Get &&
                     m.RequestUri.ToString() == "/documents"));
         }
@@ -256,7 +256,7 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_returns_one_document_for_each_returned_by_the_API()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetAllDocuments(ci.Arg<HttpRequestMessageTemplate>()));
 
             var documents = await _sut.GetAllDocuments();
@@ -270,7 +270,7 @@ namespace Waives.Http.Tests
         public async Task GetAllDocuments_throws_if_response_is_not_success_code()
         {
             _requestSender
-                .Send(Arg.Any<HttpRequestMessageTemplate>())
+                .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>

--- a/test/Waives.Http.Tests/WaivesClientFacts.cs
+++ b/test/Waives.Http.Tests/WaivesClientFacts.cs
@@ -35,7 +35,7 @@ namespace Waives.Http.Tests
 
             using (var stream = new MemoryStream(_documentContents))
             {
-                await _sut.CreateDocument(stream);
+                await _sut.CreateDocumentAsync(stream);
             }
 
             await _requestSender
@@ -54,7 +54,7 @@ namespace Waives.Http.Tests
 
             using (var stream = new MemoryStream(_documentContents))
             {
-                await _sut.CreateDocument(stream);
+                await _sut.CreateDocumentAsync(stream);
 
                 await _requestSender
                     .Received(1)
@@ -72,7 +72,7 @@ namespace Waives.Http.Tests
 
             using (var stream = new UnseekableMemoryStream(_documentContents))
             {
-                await _sut.CreateDocument(stream);
+                await _sut.CreateDocumentAsync(stream);
 
                 await _requestSender
                     .Received(1)
@@ -94,7 +94,7 @@ namespace Waives.Http.Tests
                 .SendAsync(Arg.Is<HttpRequestMessageTemplate>(m => m.RequestUri.ToString().Contains("/classify")))
                 .Returns(ci => Response.Classify(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.CreateDocument(filePath);
+            await _sut.CreateDocumentAsync(filePath);
 
             await _requestSender
                 .Received(1)
@@ -111,7 +111,7 @@ namespace Waives.Http.Tests
                 .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.CreateDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.CreateDocument(fileUri);
+            await _sut.CreateDocumentAsync(fileUri);
 
             var expectedJsonContent = new JsonContent(new ImportDocumentRequest
             {
@@ -137,7 +137,7 @@ namespace Waives.Http.Tests
 
             using (var stream = new MemoryStream(_documentContents))
             {
-                var document = await _sut.CreateDocument(stream);
+                var document = await _sut.CreateDocumentAsync(stream);
 
                 Assert.Equal("expectedDocumentId", document.Id);
 
@@ -165,7 +165,7 @@ namespace Waives.Http.Tests
             using (var stream = new MemoryStream(_documentContents))
             {
                 var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                    _sut.CreateDocument(stream));
+                    _sut.CreateDocumentAsync(stream));
 
                 Assert.Equal(Response.ErrorMessage, exception.Message);
             }
@@ -174,7 +174,7 @@ namespace Waives.Http.Tests
         [Fact]
         public async Task CreateDocument_throws_if_stream_is_empty()
         {
-            var exception = await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateDocument(Stream.Null));
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateDocumentAsync(Stream.Null));
             Assert.Contains("The provided stream has no content.", exception.Message);
             Assert.Equal("documentSource", exception.ParamName);
         }
@@ -182,14 +182,14 @@ namespace Waives.Http.Tests
         [Fact]
         public async Task CreateDocument_throws_if_stream_is_null()
         {
-            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.CreateDocument((Stream)null));
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.CreateDocumentAsync((Stream)null));
             Assert.Equal("documentSource", exception.ParamName);
         }
 
         [Fact]
         public async Task CreateDocument_throws_if_unseekable_stream_is_empty()
         {
-            var exception = await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateDocument(new UnseekableMemoryStream()));
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateDocumentAsync(new UnseekableMemoryStream()));
             Assert.Contains("The provided stream has no content.", exception.Message);
             Assert.Equal("documentSource", exception.ParamName);
         }
@@ -202,7 +202,7 @@ namespace Waives.Http.Tests
                 .Returns(ci => Response.GetDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
             var documentId = $"anonymousString{Guid.NewGuid()}";
-            await _sut.GetDocument(documentId);
+            await _sut.GetDocumentAsync(documentId);
 
             await _requestSender
                 .Received(1)
@@ -218,7 +218,7 @@ namespace Waives.Http.Tests
                 .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetDocument(ci.Arg<HttpRequestMessageTemplate>()));
 
-            var document = await _sut.GetDocument($"anonymousString{Guid.NewGuid()}");
+            var document = await _sut.GetDocumentAsync($"anonymousString{Guid.NewGuid()}");
 
             Assert.Equal("expectedDocumentId1", document.Id);
         }
@@ -231,7 +231,7 @@ namespace Waives.Http.Tests
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.GetDocument($"anonymousString{Guid.NewGuid()}"));
+                _sut.GetDocumentAsync($"anonymousString{Guid.NewGuid()}"));
 
             Assert.Equal(Response.ErrorMessage, exception.Message);
         }
@@ -243,7 +243,7 @@ namespace Waives.Http.Tests
                 .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetAllDocuments(ci.Arg<HttpRequestMessageTemplate>()));
 
-            await _sut.GetAllDocuments();
+            await _sut.GetAllDocumentsAsync();
 
             await _requestSender
                 .Received(1)
@@ -259,7 +259,7 @@ namespace Waives.Http.Tests
                 .SendAsync(Arg.Any<HttpRequestMessageTemplate>())
                 .Returns(ci => Response.GetAllDocuments(ci.Arg<HttpRequestMessageTemplate>()));
 
-            var documents = await _sut.GetAllDocuments();
+            var documents = await _sut.GetAllDocumentsAsync();
 
             var documentsArray = documents.ToArray();
             Assert.Equal("expectedDocumentId1", documentsArray.First().Id);
@@ -274,7 +274,7 @@ namespace Waives.Http.Tests
                 .Throws(new WaivesApiException(Response.ErrorMessage));
 
             var exception = await Assert.ThrowsAsync<WaivesApiException>(() =>
-                _sut.GetAllDocuments());
+                _sut.GetAllDocumentsAsync());
 
             Assert.Equal(Response.ErrorMessage, exception.Message);
         }

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -23,9 +23,9 @@ namespace Waives.Pipelines.Tests
         public PipelineFacts()
         {
             _httpDocument = Substitute.For<IHttpDocument>();
-            _httpDocument.Classify(Arg.Any<string>()).Returns(new ClassificationResult());
-            _httpDocument.Extract(Arg.Any<string>()).Returns(new ExtractionResults());
-            _httpDocument.Delete();
+            _httpDocument.ClassifyAsync(Arg.Any<string>()).Returns(new ClassificationResult());
+            _httpDocument.ExtractAsync(Arg.Any<string>()).Returns(new ExtractionResults());
+            _httpDocument.DeleteAsync();
 
             _documentFactory
                 .CreateDocument(Arg.Any<Document>())
@@ -70,7 +70,7 @@ namespace Waives.Pipelines.Tests
 
             await pipeline.RunAsync();
 
-            await _httpDocument.Received(1).Classify(classifierName);
+            await _httpDocument.Received(1).ClassifyAsync(classifierName);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Waives.Pipelines.Tests
                 .Then(t => { Assert.NotNull(t.ExtractionResults); });
 
             await pipeline.RunAsync();
-            await _httpDocument.Received(1).Extract(extractorName);
+            await _httpDocument.Received(1).ExtractAsync(extractorName);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Waives.Pipelines.Tests
         {
             var expectedStream = new MemoryStream(Generate.Bytes());
             _httpDocument
-                .Redact(Arg.Any<string>())
+                .RedactAsync(Arg.Any<string>())
                 .Returns(expectedStream);
 
             var source = Observable.Return(new TestDocument(Generate.Bytes()));
@@ -109,7 +109,7 @@ namespace Waives.Pipelines.Tests
                 });
 
             await pipeline.RunAsync();
-            await _httpDocument.Received(1).Redact(extractorName);
+            await _httpDocument.Received(1).RedactAsync(extractorName);
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace Waives.Pipelines.Tests
             var source = Observable.Repeat(new TestDocument(Generate.Bytes()), 1);
             await _sut
                 .WithDocumentsFrom(source)
-                .Then(d => d.HttpDocument.Received(1).Delete())
+                .Then(d => d.HttpDocument.Received(1).DeleteAsync())
                 .RunAsync();
         }
 
@@ -294,7 +294,7 @@ namespace Waives.Pipelines.Tests
         public async Task RunAsync_throws_if_document_deletion_fails()
         {
             var expectedException = new Exception();
-            _httpDocument.Delete().Throws(expectedException);
+            _httpDocument.DeleteAsync().Throws(expectedException);
             var source = Observable.Return(new TestDocument(Generate.Bytes()));
 
             var pipeline = _sut

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -28,7 +28,7 @@ namespace Waives.Pipelines.Tests
             _httpDocument.DeleteAsync();
 
             _documentFactory
-                .CreateDocument(Arg.Any<Document>())
+                .CreateDocumentAsync(Arg.Any<Document>())
                 .Returns(_httpDocument);
 
             _sut = new Pipeline(_documentFactory, 10);
@@ -54,7 +54,7 @@ namespace Waives.Pipelines.Tests
             var pipeline = _sut.WithDocumentsFrom(source);
             await pipeline.RunAsync();
 
-            await _documentFactory.Received(1).CreateDocument(testDocument);
+            await _documentFactory.Received(1).CreateDocumentAsync(testDocument);
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace Waives.Pipelines.Tests
             var source = Observable.Repeat(document, 1);
 
             _documentFactory
-                .CreateDocument(Arg.Any<Document>())
+                .CreateDocumentAsync(Arg.Any<Document>())
                 .Throws(exception);
 
             await _sut.WithDocumentsFrom(source)
@@ -269,7 +269,7 @@ namespace Waives.Pipelines.Tests
             var source = Observable.Repeat(document, 1);
 
             _documentFactory
-                .CreateDocument(Arg.Any<Document>())
+                .CreateDocumentAsync(Arg.Any<Document>())
                 .Throws(exception);
 
             await _sut.WithDocumentsFrom(source)


### PR DESCRIPTION
This PR tackles the first item in #84, to rename all `async` methods to have an `Async` suffix.