### PR TITLE
Add CancellationToken support to async methods

### DIFF
--- a/src/Waives.Http/RequestHandling/FailedRequestHandlingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/FailedRequestHandlingRequestSender.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Waives.Http.Responses;
 
@@ -19,9 +20,9 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
-            var response = await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
+            var response = await _wrappedRequestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 return response;

--- a/src/Waives.Http/RequestHandling/IHttpRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/IHttpRequestSender.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Http.RequestHandling
@@ -7,6 +8,6 @@ namespace Waives.Http.RequestHandling
     {
         int Timeout { get; set; }
 
-        Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Waives.Http/RequestHandling/LoggingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/LoggingRequestSender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Waives.Http.Logging;
 
@@ -22,7 +23,7 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
             var stopWatch = new Stopwatch();
             Logger.Trace("Sending {RequestMethod} request to {RequestUri}", request.Method, request.RequestUri);
@@ -30,7 +31,7 @@ namespace Waives.Http.RequestHandling
             try
             {
                 stopWatch.Start();
-                var response = await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
+                var response = await _wrappedRequestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 stopWatch.Stop();
 
                 Logger.Trace(

--- a/src/Waives.Http/RequestHandling/ReliableRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/ReliableRequestSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Polly;
 using Polly.Extensions.Http;
@@ -33,11 +34,11 @@ namespace Waives.Http.RequestHandling
             set => _wrappedRequestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
             return await _policy
                 .ExecuteAsync(() =>
-                    _wrappedRequestSender.SendAsync(request))
+                    _wrappedRequestSender.SendAsync(request, cancellationToken))
                 .ConfigureAwait(false);
         }
 

--- a/src/Waives.Http/RequestHandling/RequestSender.cs
+++ b/src/Waives.Http/RequestHandling/RequestSender.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Http.RequestHandling
@@ -28,10 +29,10 @@ namespace Waives.Http.RequestHandling
             set => _httpClient.Timeout = TimeSpan.FromSeconds(value);
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate template)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate template, CancellationToken cancellationToken = default)
         {
             var request = template.CreateRequest();
-            return await _httpClient.SendAsync(request).ConfigureAwait(false);
+            return await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Http/RequestHandling/TimeoutHandlingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TimeoutHandlingRequestSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Http.RequestHandling
@@ -24,12 +25,13 @@ namespace Waives.Http.RequestHandling
         /// into a WaivesApiException.
         /// </summary>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
             try
             {
-                return await _wrappedRequestSender.SendAsync(request).ConfigureAwait(false);
+                return await _wrappedRequestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is TaskCanceledException || e is OperationCanceledException)
             {

--- a/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
@@ -24,7 +24,7 @@ namespace Waives.Http.RequestHandling
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
-            var token = await _accessTokenService.FetchAccessTokenAsync().ConfigureAwait(false);
+            var token = await _accessTokenService.FetchAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             request.Headers["Authorization"] = $"Bearer {token}";
 
             return await _requestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
+++ b/src/Waives.Http/RequestHandling/TokenFetchingRequestSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Http.RequestHandling
@@ -21,12 +22,12 @@ namespace Waives.Http.RequestHandling
             set => _requestSender.Timeout = value;
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessageTemplate request, CancellationToken cancellationToken = default)
         {
             var token = await _accessTokenService.FetchAccessTokenAsync().ConfigureAwait(false);
             request.Headers["Authorization"] = $"Bearer {token}";
 
-            return await _requestSender.SendAsync(request).ConfigureAwait(false);
+            return await _requestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Waives.Pipelines/ConcurrentPipelineObserver.cs
+++ b/src/Waives.Pipelines/ConcurrentPipelineObserver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Pipelines
@@ -8,6 +9,7 @@ namespace Waives.Pipelines
         private readonly IDocumentProcessor _documentProcessor;
         private readonly Action _onPipelineCompleted;
         private readonly Action<Exception> _onError;
+        private readonly CancellationToken _cancellationToken;
 
         private readonly WorkPool _workPool;
 
@@ -15,18 +17,20 @@ namespace Waives.Pipelines
             IDocumentProcessor documentProcessor,
             Action onPipelineCompleted,
             Action<Exception> onError,
-            int maxConcurrency)
+            int maxConcurrency,
+            CancellationToken cancellationToken = default)
         {
             _documentProcessor = documentProcessor ?? throw new ArgumentNullException(nameof(documentProcessor));
             _onPipelineCompleted = onPipelineCompleted ?? throw new ArgumentNullException(nameof(onPipelineCompleted));
             _onError = onError ?? throw new ArgumentNullException(nameof(onError));
+            _cancellationToken = cancellationToken;
             _workPool = new WorkPool(maxConcurrency);
         }
 
         public void OnCompleted()
         {
-             _workPool.WaitAsync()
-                .ContinueWith(_ => _onPipelineCompleted())
+             _workPool.WaitAsync(_cancellationToken)
+                .ContinueWith(_ => _onPipelineCompleted(), _cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -39,7 +43,9 @@ namespace Waives.Pipelines
 
         public void OnNext(Document document)
         {
-            _workPool.Post(async () => await _documentProcessor.RunAsync(document));
+            _workPool.Post(
+                async () => await _documentProcessor.RunAsync(document, _cancellationToken),
+                _cancellationToken);
         }
 
         private void Dispose(bool disposing)

--- a/src/Waives.Pipelines/DocumentProcessor.cs
+++ b/src/Waives.Pipelines/DocumentProcessor.cs
@@ -7,14 +7,14 @@ namespace Waives.Pipelines
 {
     internal class DocumentProcessor : IDocumentProcessor
     {
-        private readonly Func<Document, Task<WaivesDocument>> _docCreator;
-        private readonly IEnumerable<Func<WaivesDocument, Task<WaivesDocument>>> _docActions;
-        private readonly Func<WaivesDocument, Task> _docDeleter;
+        private readonly Func<Document, CancellationToken, Task<WaivesDocument>> _docCreator;
+        private readonly IEnumerable<Func<WaivesDocument, CancellationToken, Task<WaivesDocument>>> _docActions;
+        private readonly Func<WaivesDocument, CancellationToken, Task> _docDeleter;
         private readonly Action<Exception, Document> _onDocumentException;
 
-        public DocumentProcessor(Func<Document, Task<WaivesDocument>> docCreator,
-            IEnumerable<Func<WaivesDocument, Task<WaivesDocument>>> docActions,
-            Func<WaivesDocument, Task> docDeleter,
+        public DocumentProcessor(Func<Document, CancellationToken, Task<WaivesDocument>> docCreator,
+            IEnumerable<Func<WaivesDocument, CancellationToken, Task<WaivesDocument>>> docActions,
+            Func<WaivesDocument, CancellationToken, Task> docDeleter,
             Action<Exception, Document> onDocumentException)
         {
             _docCreator = docCreator ?? throw new ArgumentNullException(nameof(docCreator));
@@ -23,13 +23,13 @@ namespace Waives.Pipelines
             _onDocumentException = onDocumentException ?? throw new ArgumentNullException(nameof(onDocumentException));
         }
 
-        public async Task RunAsync(Document document)
+        public async Task RunAsync(Document document, CancellationToken cancellationToken = default)
         {
             WaivesDocument waivesDocument = null;
             try
             {
-                waivesDocument = await _docCreator(document);
-                await RunActionsAsync(waivesDocument).ConfigureAwait(false);
+                waivesDocument = await _docCreator(document, cancellationToken);
+                await RunActionsAsync(waivesDocument, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -39,16 +39,16 @@ namespace Waives.Pipelines
             {
                 if (waivesDocument != null)
                 {
-                    await _docDeleter(waivesDocument);
+                    await _docDeleter(waivesDocument, cancellationToken);
                 }
             }
         }
 
-        private async Task RunActionsAsync(WaivesDocument document)
+        private async Task RunActionsAsync(WaivesDocument document, CancellationToken cancellationToken = default)
         {
             foreach (var docAction in _docActions)
             {
-                document = await docAction(document).ConfigureAwait(false);
+                document = await docAction(document, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Waives.Http.Responses;
 
@@ -11,13 +12,13 @@ namespace Waives.Pipelines.HttpAdapters
     /// </summary>
     internal interface IHttpDocument
     {
-        Task<ClassificationResult> ClassifyAsync(string classifierName);
+        Task<ClassificationResult> ClassifyAsync(string classifierName, CancellationToken cancellationToken = default);
 
-        Task<ExtractionResults> ExtractAsync(string extractorName);
+        Task<ExtractionResults> ExtractAsync(string extractorName, CancellationToken cancellationToken = default);
 
-        Task<Stream> RedactAsync(string extractorName);
+        Task<Stream> RedactAsync(string extractorName, CancellationToken cancellationToken = default);
 
-        Task DeleteAsync();
+        Task DeleteAsync(CancellationToken cancellationToken = default);
 
         string Id { get; }
     }
@@ -39,24 +40,32 @@ namespace Waives.Pipelines.HttpAdapters
             _documentClient = documentClient;
         }
 
-        public async Task<ClassificationResult> ClassifyAsync(string classifierName)
+        public async Task<ClassificationResult> ClassifyAsync(string classifierName, CancellationToken cancellationToken = default)
         {
-            return await _documentClient.ClassifyAsync(classifierName).ConfigureAwait(false);
+            return await _documentClient
+                .ClassifyAsync(classifierName, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        public async Task<ExtractionResults> ExtractAsync(string extractorName)
+        public async Task<ExtractionResults> ExtractAsync(string extractorName, CancellationToken cancellationToken = default)
         {
-            return await _documentClient.ExtractAsync(extractorName).ConfigureAwait(false);
+            return await _documentClient
+                .ExtractAsync(extractorName, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        public async Task<Stream> RedactAsync(string extractorName)
+        public async Task<Stream> RedactAsync(string extractorName, CancellationToken cancellationToken = default)
         {
-            return await _documentClient.RedactAsync(extractorName).ConfigureAwait(false);
+            return await _documentClient
+                .RedactAsync(extractorName, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        public async Task DeleteAsync()
+        public async Task DeleteAsync(CancellationToken cancellationToken = default)
         {
-            await _documentClient.DeleteAsync().ConfigureAwait(false);
+            await _documentClient
+                .DeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Pipelines/HttpAdapters/LoggingDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/LoggingDocumentFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Waives.Http.Logging;
 
 namespace Waives.Pipelines.HttpAdapters
@@ -14,9 +15,11 @@ namespace Waives.Pipelines.HttpAdapters
             _wrappedDocumentFactory = underlyingDocumentFactory;
         }
 
-        public async Task<IHttpDocument> CreateDocumentAsync(Document source)
+        public async Task<IHttpDocument> CreateDocumentAsync(Document source, CancellationToken cancellationToken = default)
         {
-            var httpDocument = await _wrappedDocumentFactory.CreateDocumentAsync(source).ConfigureAwait(false);
+            var httpDocument = await _wrappedDocumentFactory
+                .CreateDocumentAsync(source, cancellationToken)
+                .ConfigureAwait(false);
 
             Logger.Info(
                 "Created Waives document {DocumentId} from '{DocumentSourceId}'",

--- a/src/Waives.Pipelines/IDocumentProcessor.cs
+++ b/src/Waives.Pipelines/IDocumentProcessor.cs
@@ -1,9 +1,10 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Pipelines
 {
     internal interface IDocumentProcessor
     {
-        Task RunAsync(Document document);
+        Task RunAsync(Document document, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Waives.Pipelines/ObservableProcessExtension.cs
+++ b/src/Waives.Pipelines/ObservableProcessExtension.cs
@@ -10,7 +10,8 @@ namespace Waives.Pipelines
         internal static IObservable<WaivesDocument> Process<TDocument>(
             this IObservable<TDocument> documents,
             Func<TDocument, Task<WaivesDocument>> processAction,
-            Action<DocumentError> errorAction)
+            Action<DocumentError> errorAction,
+            CancellationToken cancellationToken = default)
         {
             var results = documents.SelectMany(async d =>
             {
@@ -22,7 +23,9 @@ namespace Waives.Pipelines
                 catch (Exception e)
                 {
                     var documentError = await OnProcessingErrorAsync(
-                        new ProcessingError<TDocument>(d, e)).ConfigureAwait(false);
+                            new ProcessingError<TDocument>(d, e),
+                            cancellationToken)
+                        .ConfigureAwait(false);
 
                     errorAction(documentError);
 

--- a/src/Waives.Pipelines/ObservableProcessExtension.cs
+++ b/src/Waives.Pipelines/ObservableProcessExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Waives.Pipelines
@@ -32,14 +33,14 @@ namespace Waives.Pipelines
             return results.Select(r => r.Document);
         }
 
-        private static async Task<DocumentError> OnProcessingErrorAsync<TDocument>(ProcessingError<TDocument> error)
+        private static async Task<DocumentError> OnProcessingErrorAsync<TDocument>(ProcessingError<TDocument> error, CancellationToken cancellationToken = default)
         {
             // Try coercing the document in error to a Waives Document. If it is, it
             // has been created in the platform and must be deleted before proceeding.
             var waivesDocument = error.Document as WaivesDocument;
             if (waivesDocument != null)
             {
-                await waivesDocument.DeleteAsync().ConfigureAwait(false);
+                await waivesDocument.DeleteAsync(cancellationToken).ConfigureAwait(false);
                 return new DocumentError(waivesDocument.Source, error.Exception);
             }
 

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -373,7 +373,8 @@ namespace Waives.Pipelines
                 documentProcessor,
                 OnPipelineComplete,
                 OnPipelineError,
-                _maxConcurrency);
+                _maxConcurrency,
+                cancellationToken);
 
             var connection = _docSource.Subscribe(pipelineObserver);
             try

--- a/src/Waives.Pipelines/WaivesApi.cs
+++ b/src/Waives.Pipelines/WaivesApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Waives.Http;
 using Waives.Pipelines.HttpAdapters;
@@ -56,15 +57,21 @@ namespace Waives.Pipelines
         /// ]]>
         /// </example>
         /// <param name="options"></param>
+        /// <param name="cancellationToken">
+        /// The token to monitor for cancellation requests. The default value is
+        /// <see cref="CancellationToken.None"/>.
+        /// </param>
         /// <returns>A new <see cref="Pipeline"/> instance with which you can
         /// configure your document processing pipeline.</returns>
-        public static async Task<Pipeline> CreatePipelineAsync(WaivesOptions options)
+        public static async Task<Pipeline> CreatePipelineAsync(WaivesOptions options, CancellationToken cancellationToken = default)
         {
             var waivesClient = CreateAuthenticatedWaivesClient(options);
 
             var documentFactory = await HttpDocumentFactory.CreateAsync(
-                waivesClient,
-                options.DeleteExistingDocuments).ConfigureAwait(false);
+                    waivesClient,
+                    options.DeleteExistingDocuments,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             return new Pipeline(
                 documentFactory,

--- a/src/Waives.Pipelines/WorkPool.cs
+++ b/src/Waives.Pipelines/WorkPool.cs
@@ -23,9 +23,10 @@ namespace Waives.Pipelines
         /// level of concurrency, Post blocks until one of the in-flight Tasks has completed.
         /// </summary>
         /// <param name="action"></param>
-        public void Post(Func<Task> action)
+        /// <param name="cancellationToken"></param>
+        public void Post(Func<Task> action, CancellationToken cancellationToken = default)
         {
-            _semaphore.Wait();
+            _semaphore.Wait(cancellationToken);
 
             var task = action();
             _tasks.TryAdd(task, true);
@@ -41,9 +42,9 @@ namespace Waives.Pipelines
         /// Waits for all currently executing tasks.
         /// </summary>
         /// <returns></returns>
-        public async Task WaitAsync()
+        public async Task WaitAsync(CancellationToken cancellationToken = default)
         {
-            await _semaphore.WaitAsync();
+            await _semaphore.WaitAsync(cancellationToken);
             await Task.WhenAll(_tasks.Keys.ToArray());
             _semaphore.Release();
         }


### PR DESCRIPTION
This PR adds an optional `CancellationToken` parameter to all async methods, with a default value of `CancellationToken.None`, to address the second point in #84.