### PR TITLE
Do not allow document deletions to be cancelled

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -34,18 +34,14 @@ namespace Waives.Http
         /// <summary>
         /// Deletes this document in the Waives platform.
         /// </summary>
-        /// <param name="cancellationToken">
-        /// The token to monitor for cancellation requests. The default value is
-        /// <see cref="CancellationToken.None"/>.
-        /// </param>
-        public async Task DeleteAsync(CancellationToken cancellationToken = default)
+        public async Task DeleteAsync()
         {
             var selfUrl = _behaviours["self"];
 
             var request = new HttpRequestMessageTemplate(HttpMethod.Delete,
                 selfUrl.CreateUri());
 
-            await _requestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            await _requestSender.SendAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Waives.Pipelines/DocumentProcessor.cs
+++ b/src/Waives.Pipelines/DocumentProcessor.cs
@@ -9,12 +9,12 @@ namespace Waives.Pipelines
     {
         private readonly Func<Document, CancellationToken, Task<WaivesDocument>> _docCreator;
         private readonly IEnumerable<Func<WaivesDocument, CancellationToken, Task<WaivesDocument>>> _docActions;
-        private readonly Func<WaivesDocument, CancellationToken, Task> _docDeleter;
+        private readonly Func<WaivesDocument, Task> _docDeleter;
         private readonly Action<Exception, Document> _onDocumentException;
 
         public DocumentProcessor(Func<Document, CancellationToken, Task<WaivesDocument>> docCreator,
             IEnumerable<Func<WaivesDocument, CancellationToken, Task<WaivesDocument>>> docActions,
-            Func<WaivesDocument, CancellationToken, Task> docDeleter,
+            Func<WaivesDocument, Task> docDeleter,
             Action<Exception, Document> onDocumentException)
         {
             _docCreator = docCreator ?? throw new ArgumentNullException(nameof(docCreator));
@@ -39,7 +39,7 @@ namespace Waives.Pipelines
             {
                 if (waivesDocument != null)
                 {
-                    await _docDeleter(waivesDocument, cancellationToken);
+                    await _docDeleter(waivesDocument);
                 }
             }
         }

--- a/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
+++ b/src/Waives.Pipelines/HttpAdapters/HttpDocument.cs
@@ -18,7 +18,7 @@ namespace Waives.Pipelines.HttpAdapters
 
         Task<Stream> RedactAsync(string extractorName, CancellationToken cancellationToken = default);
 
-        Task DeleteAsync(CancellationToken cancellationToken = default);
+        Task DeleteAsync();
 
         string Id { get; }
     }
@@ -61,10 +61,10 @@ namespace Waives.Pipelines.HttpAdapters
                 .ConfigureAwait(false);
         }
 
-        public async Task DeleteAsync(CancellationToken cancellationToken = default)
+        public async Task DeleteAsync()
         {
             await _documentClient
-                .DeleteAsync(cancellationToken)
+                .DeleteAsync()
                 .ConfigureAwait(false);
         }
     }

--- a/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
@@ -57,7 +57,7 @@ namespace Waives.Pipelines.HttpAdapters
         private static async Task DeleteOrphanedDocumentsAsync(WaivesClient apiClient, CancellationToken cancellationToken = default)
         {
             var orphanedDocuments = await apiClient.GetAllDocumentsAsync(cancellationToken).ConfigureAwait(false);
-            await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync(cancellationToken))).ConfigureAwait(false);
+            await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync())).ConfigureAwait(false);
         }
     }
 }

--- a/src/Waives.Pipelines/ObservableProcessExtension.cs
+++ b/src/Waives.Pipelines/ObservableProcessExtension.cs
@@ -43,7 +43,7 @@ namespace Waives.Pipelines
             var waivesDocument = error.Document as WaivesDocument;
             if (waivesDocument != null)
             {
-                await waivesDocument.DeleteAsync(cancellationToken).ConfigureAwait(false);
+                await waivesDocument.DeleteAsync().ConfigureAwait(false);
                 return new DocumentError(waivesDocument.Source, error.Exception);
             }
 

--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -342,11 +342,11 @@ namespace Waives.Pipelines
                 return new WaivesDocument(d, httpDocument);
             };
 
-            Func<WaivesDocument, CancellationToken, Task> docDeleter = async (d, ct) =>
+            Func<WaivesDocument, Task> docDeleter = async d =>
             {
                 try
                 {
-                    await d.HttpDocument.DeleteAsync(ct).ConfigureAwait(false);
+                    await d.HttpDocument.DeleteAsync().ConfigureAwait(false);
 
                     _logger.Info(
                         "Deleted document {DocumentId}. Processing of '{DocumentSourceId}' complete.",

--- a/src/Waives.Pipelines/WaivesDocument.cs
+++ b/src/Waives.Pipelines/WaivesDocument.cs
@@ -75,9 +75,9 @@ namespace Waives.Pipelines
             return this;
         }
 
-        public async Task DeleteAsync(CancellationToken cancellationToken = default)
+        public async Task DeleteAsync()
         {
-            await _waivesDocument.DeleteAsync(cancellationToken).ConfigureAwait(false);
+            await _waivesDocument.DeleteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/test/Waives.Pipelines.Tests/DocumentProcessorFacts.cs
+++ b/test/Waives.Pipelines.Tests/DocumentProcessorFacts.cs
@@ -12,7 +12,7 @@ namespace Waives.Pipelines.Tests
     public class DocumentProcessorFacts
     {
         private readonly Func<Document, CancellationToken, Task<WaivesDocument>> _docCreator;
-        private readonly Func<WaivesDocument, CancellationToken, Task> _docDeleter;
+        private readonly Func<WaivesDocument, Task> _docDeleter;
         private readonly Action<Exception, Document> _onDocumentException;
         private readonly TestDocument _testDocument;
 
@@ -23,7 +23,7 @@ namespace Waives.Pipelines.Tests
                 var waivesDocument = new WaivesDocument(document, Substitute.For<IHttpDocument>());
                 return Task.FromResult(waivesDocument);
             };
-            _docDeleter = (document, cancellationToken) => Task.CompletedTask;
+            _docDeleter = _ => Task.CompletedTask;
             _onDocumentException = (exception, document) => { };
             _testDocument = new TestDocument(Generate.Bytes());
         }
@@ -88,7 +88,7 @@ namespace Waives.Pipelines.Tests
         public async Task Deletes_document_after_error()
         {
             var docDeleted = false;
-            Func<WaivesDocument, CancellationToken, Task> docDeleter = (document, cancellationToken) =>
+            Func<WaivesDocument, Task> docDeleter = document =>
             {
                 docDeleted = true;
                 return Task.CompletedTask;
@@ -109,7 +109,7 @@ namespace Waives.Pipelines.Tests
         public async Task Deletes_document_after_error_in_error_handler()
         {
             var docDeleted = false;
-            Func<WaivesDocument, CancellationToken, Task> docDeleter = (document, cancellationToken) =>
+            Func<WaivesDocument, Task> docDeleter = document =>
             {
                 docDeleted = true;
                 return Task.CompletedTask;


### PR DESCRIPTION
We always want these requests to complete, so remove the `CancellationToken` parameter from the `Delete()` methods and delegates.