### PR TITLE
Do allow HTTP library to cancel document deletion

### DIFF
--- a/src/Waives.Http/Document.cs
+++ b/src/Waives.Http/Document.cs
@@ -34,14 +34,14 @@ namespace Waives.Http
         /// <summary>
         /// Deletes this document in the Waives platform.
         /// </summary>
-        public async Task DeleteAsync()
+        public async Task DeleteAsync(CancellationToken cancellationToken = default)
         {
             var selfUrl = _behaviours["self"];
 
             var request = new HttpRequestMessageTemplate(HttpMethod.Delete,
                 selfUrl.CreateUri());
 
-            await _requestSender.SendAsync(request).ConfigureAwait(false);
+            await _requestSender.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
+++ b/src/Waives.Pipelines/HttpAdapters/WaivesDocumentFactory.cs
@@ -57,7 +57,7 @@ namespace Waives.Pipelines.HttpAdapters
         private static async Task DeleteOrphanedDocumentsAsync(WaivesClient apiClient, CancellationToken cancellationToken = default)
         {
             var orphanedDocuments = await apiClient.GetAllDocumentsAsync(cancellationToken).ConfigureAwait(false);
-            await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync())).ConfigureAwait(false);
+            await Task.WhenAll(orphanedDocuments.Select(d => d.DeleteAsync(cancellationToken))).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
As per @phildrip's comment on #96, the HTTP library's `Document.DeleteAsync()` operation should be cancellable. Additionally, in the Pipelines library, we can allow `DeleteOrphanedDocuments()` to be cancelled too.