### PR TITLE
Set exception if completion throws

### DIFF
--- a/src/Waives.Pipelines/Pipeline.cs
+++ b/src/Waives.Pipelines/Pipeline.cs
@@ -341,9 +341,16 @@ namespace Waives.Pipelines
 
             void OnPipelineComplete()
             {
-                _onPipelineCompletedUserAction();
-                Logger.Info("Pipeline complete");
-                taskCompletion.SetResult(true);
+                try
+                {
+                    _onPipelineCompletedUserAction();
+                    Logger.Info("Pipeline complete");
+                    taskCompletion.SetResult(true);
+                }
+                catch (Exception e)
+                {
+                    taskCompletion.TrySetException(e);
+                }
             }
 
             void OnPipelineError(Exception e)

--- a/test/Waives.Pipelines.Tests/PipelineFacts.cs
+++ b/test/Waives.Pipelines.Tests/PipelineFacts.cs
@@ -304,6 +304,21 @@ namespace Waives.Pipelines.Tests
             Assert.Same(expectedException, actualException);
         }
 
+        [Fact]
+        public async Task RunAsync_throws_if_completion_callback_fails()
+        {
+            var expectedException = new Exception();
+            var source = Observable.Return(new TestDocument(Generate.Bytes()));
+
+            var pipeline = _sut
+                .WithDocumentsFrom(source)
+                .OnPipelineCompleted(() => throw expectedException);
+
+            var actualException = await Assert.ThrowsAsync<Exception>(() => pipeline.RunAsync());
+
+            Assert.Same(expectedException, actualException);
+        }
+
         private static void AssertStreamsAreEqual(MemoryStream expected, Stream actual)
         {
             var actualMemoryStream = new MemoryStream();


### PR DESCRIPTION
If the pipeline completion callback throws for any reason, we need to propagate this back to the calling thread, otherwise it will deadlock. This was demonstrated by writing the test first and watching it hang. With the `try..catch` in place in the `Pipeline`, the test completes successfully.